### PR TITLE
expose sendHeaders() API

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -69,6 +69,26 @@ fastify.get('/live', { sse: true }, async (request, reply) => {
   })
 })
 
+// Custom headers with sendHeaders
+fastify.get('/headers', { sse: true }, async (request, reply) => {
+  // Set custom headers using Fastify's header methods
+  reply.header('X-Session-ID', 'session-12345')
+  reply.header('X-API-Version', 'v1.2.3')
+  reply.headers({
+    'X-User-Agent': request.headers['user-agent'] || 'unknown',
+    'X-Request-Time': new Date().toISOString()
+  })
+
+  // Manually send headers before any SSE data
+  reply.sse.sendHeaders()
+
+  // Now send SSE data
+  await reply.sse.send({
+    data: 'Headers sent manually before this message',
+    event: 'custom-headers'
+  })
+})
+
 // Replay functionality
 const messageHistory = []
 let eventId = 0
@@ -111,6 +131,7 @@ const start = async () => {
     console.log('  GET /events - Basic SSE messages')
     console.log('  GET /stream - Streaming with async generator')
     console.log('  GET /live - Persistent connection with heartbeat')
+    console.log('  GET /headers - Custom headers with sendHeaders()')
     console.log('  GET /replay - Messages with replay support')
   } catch (err) {
     fastify.log.error(err)

--- a/index.js
+++ b/index.js
@@ -81,26 +81,31 @@ function createSSETransformStream (options = {}) {
  * SSE Context class for managing connection state
  */
 class SSEContext {
+  #lastEventId
+  #isConnected
+  #keepAlive
+  #headersSent
+
   constructor (options) {
     this.reply = options.reply
-    this._lastEventId = options.lastEventId || null
-    this._isConnected = true
-    this._keepAlive = false
-    this._headersSent = false
+    this.#lastEventId = options.lastEventId || null
+    this.#isConnected = true
+    this.#keepAlive = false
+    this.#headersSent = false
     this.heartbeatTimer = null
     this.closeCallbacks = []
     this.serializer = options.serializer
 
     // Set up connection close handler
     this.reply.raw.on('close', () => {
-      this._isConnected = false
+      this.#isConnected = false
       this.cleanup()
     })
 
     // Handle errors on the raw response to prevent uncaught exceptions
     this.reply.raw.on('error', (error) => {
       // Client disconnection is expected behavior, handle gracefully
-      this._isConnected = false
+      this.#isConnected = false
       this.cleanup()
       // Log as info since client disconnections are normal
       this.reply.log.info({ err: error }, 'SSE connection closed')
@@ -117,7 +122,7 @@ class SSEContext {
    * @returns {string|null} The last event ID or null if not present
    */
   get lastEventId () {
-    return this._lastEventId
+    return this.#lastEventId
   }
 
   /**
@@ -125,7 +130,15 @@ class SSEContext {
    * @returns {boolean} True if connected, false otherwise
    */
   get isConnected () {
-    return this._isConnected
+    return this.#isConnected
+  }
+
+  /**
+   * Checks if the connection should be kept alive after handler completion.
+   * @returns {boolean} True if connection should be kept alive
+   */
+  get shouldKeepAlive () {
+    return this.#keepAlive
   }
 
   /**
@@ -133,7 +146,7 @@ class SSEContext {
    * Without calling this, the connection will close after the handler returns.
    */
   keepAlive () {
-    this._keepAlive = true
+    this.#keepAlive = true
   }
 
   /**
@@ -141,9 +154,9 @@ class SSEContext {
    * Safe to call multiple times.
    */
   close () {
-    if (!this._isConnected) return
+    if (!this.#isConnected) return
 
-    this._isConnected = false
+    this.#isConnected = false
     this.cleanup()
     this.reply.raw.end()
   }
@@ -162,9 +175,9 @@ class SSEContext {
    * @param {Function} callback - Async function that receives the last event ID
    */
   async replay (callback) {
-    if (!this._lastEventId) return
+    if (!this.#lastEventId) return
 
-    await callback(this._lastEventId)
+    await callback(this.#lastEventId)
   }
 
   /**
@@ -175,7 +188,7 @@ class SSEContext {
    * also be called manually if needed.
    */
   sendHeaders () {
-    if (!this._headersSent) {
+    if (!this.#headersSent) {
       // Get any headers set via reply.header() and transfer to raw response
       const replyHeaders = this.reply.getHeaders()
       for (const [name, value] of Object.entries(replyHeaders)) {
@@ -183,7 +196,7 @@ class SSEContext {
       }
 
       this.reply.raw.writeHead(200)
-      this._headersSent = true
+      this.#headersSent = true
     }
   }
 
@@ -194,7 +207,7 @@ class SSEContext {
    * @throws {TypeError} If source type is invalid
    */
   async send (source) {
-    if (!this._isConnected) {
+    if (!this.#isConnected) {
       throw new Error('SSE connection is closed')
     }
 
@@ -214,7 +227,7 @@ class SSEContext {
         await pipeline(source, transform, this.reply.raw, { end: false })
       } catch (error) {
         // Distinguish between expected disconnection errors and unexpected errors
-        this._isConnected = false
+        this.#isConnected = false
         this.cleanup()
         if (error && (error.code === 'ECONNRESET' || error.code === 'EPIPE')) {
           this.reply.log.info({ err: error }, 'SSE stream ended (client disconnected)')
@@ -229,7 +242,7 @@ class SSEContext {
     // Handle AsyncIterable
     if (this.isAsyncIterable(source)) {
       for await (const chunk of source) {
-        if (!this._isConnected) break
+        if (!this.#isConnected) break
         const formatted = formatSSEMessage(chunk, this.serializer)
         await this.writeToStream(formatted)
       }
@@ -246,7 +259,7 @@ class SSEContext {
    * @throws {Error} If connection is closed
    */
   stream () {
-    if (!this._isConnected) {
+    if (!this.#isConnected) {
       throw new Error('SSE connection is closed')
     }
 
@@ -270,7 +283,7 @@ class SSEContext {
    */
   writeToStream (data) {
     return new Promise((resolve, reject) => {
-      if (!this._isConnected) {
+      if (!this.#isConnected) {
         reject(new Error('SSE connection is closed'))
         return
       }
@@ -292,7 +305,7 @@ class SSEContext {
         const onError = (err) => {
           this.reply.raw.off('drain', onDrain)
           // Handle all errors gracefully - client disconnection is normal
-          this._isConnected = false
+          this.#isConnected = false
           this.cleanup()
           this.reply.log.info({ err }, 'SSE write ended')
           resolve() // Resolve instead of reject for graceful handling
@@ -311,7 +324,7 @@ class SSEContext {
    */
   startHeartbeat (interval) {
     this.heartbeatTimer = setInterval(() => {
-      if (this._isConnected) {
+      if (this.#isConnected) {
         this.sendHeaders()
         this.reply.raw.write(': heartbeat\n\n')
       } else {
@@ -424,14 +437,14 @@ async function fastifySSE (fastify, opts) {
         res = await originalHandler.call(this, request, reply)
       } catch (error) {
         // If handler doesn't call keepAlive, close connection
-        if (!context._keepAlive) {
+        if (!context.shouldKeepAlive) {
           context.close()
         }
         throw error
       }
 
       // If handler doesn't call keepAlive, close connection
-      if (!context._keepAlive) {
+      if (!context.shouldKeepAlive) {
         context.close()
       }
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -19,8 +19,6 @@ test('basic SSE functionality', async (t) => {
     await reply.sse.send({ data: 'hello world' })
   })
 
-  await fastify.listen({ port: 0 })
-
   const response = await fastify.inject({
     method: 'GET',
     url: '/events',
@@ -57,8 +55,6 @@ test('SSE message formatting', async (t) => {
     })
   })
 
-  await fastify.listen({ port: 0 })
-
   const response = await fastify.inject({
     method: 'GET',
     url: '/events',
@@ -87,8 +83,6 @@ test('string message support', async (t) => {
     await reply.sse.send('plain text message')
   })
 
-  await fastify.listen({ port: 0 })
-
   const response = await fastify.inject({
     method: 'GET',
     url: '/events',
@@ -113,8 +107,6 @@ test('multiline data handling', async (t) => {
   fastify.get('/events', { sse: true }, async (request, reply) => {
     await reply.sse.send({ data: 'line1\nline2\nline3' })
   })
-
-  await fastify.listen({ port: 0 })
 
   const response = await fastify.inject({
     method: 'GET',
@@ -146,8 +138,6 @@ test('async generator support', async (t) => {
 
     await reply.sse.send(generate())
   })
-
-  await fastify.listen({ port: 0 })
 
   const response = await fastify.inject({
     method: 'GET',
@@ -184,8 +174,6 @@ test('readable stream support', async (t) => {
 
     await reply.sse.send(stream)
   })
-
-  await fastify.listen({ port: 0 })
 
   const response = await fastify.inject({
     method: 'GET',
@@ -254,8 +242,6 @@ test('custom serializer', async (t) => {
     await reply.sse.send({ data: 'test' })
   })
 
-  await fastify.listen({ port: 0 })
-
   const response = await fastify.inject({
     method: 'GET',
     url: '/events',
@@ -290,8 +276,6 @@ test('reply.sse.stream() for pipeline operations', async (t) => {
     // Use reply.sse.stream() in a pipeline
     await pipeline(sourceStream, reply.sse.stream(), reply.raw, { end: false })
   })
-
-  await fastify.listen({ port: 0 })
 
   const response = await fastify.inject({
     method: 'GET',

--- a/test/custom-headers.test.js
+++ b/test/custom-headers.test.js
@@ -23,8 +23,6 @@ test('should allow setting custom headers in SSE responses', async (t) => {
     await reply.sse.send({ data: 'hello' })
   })
 
-  await fastify.listen({ port: 0 })
-
   const response = await fastify.inject({
     method: 'GET',
     url: '/events',
@@ -61,8 +59,6 @@ test('should allow setting headers via reply.header() method', async (t) => {
 
     await reply.sse.send({ data: 'test' })
   })
-
-  await fastify.listen({ port: 0 })
 
   const response = await fastify.inject({
     method: 'GET',
@@ -101,8 +97,6 @@ test('should allow setting headers in preHandler hook', async (t) => {
 
     await reply.sse.send({ data: 'prehandler test' })
   })
-
-  await fastify.listen({ port: 0 })
 
   const response = await fastify.inject({
     method: 'GET',

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -19,8 +19,6 @@ test('Last-Event-ID header parsing', async (t) => {
     await reply.sse.send({ id: '43', data: 'next event' })
   })
 
-  await fastify.listen({ port: 0 })
-
   const response = await fastify.inject({
     method: 'GET',
     url: '/events',
@@ -67,8 +65,6 @@ test('replay functionality', async (t) => {
     await reply.sse.send({ id: '4', data: 'latest' })
   })
 
-  await fastify.listen({ port: 0 })
-
   const response = await fastify.inject({
     method: 'GET',
     url: '/events',
@@ -104,8 +100,6 @@ test('connection state during handler execution', async (t) => {
     connectionStateInHandler = reply.sse.isConnected
     await reply.sse.send({ data: 'connected' })
   })
-
-  await fastify.listen({ port: 0 })
 
   const response = await fastify.inject({
     method: 'GET',
@@ -145,8 +139,6 @@ test('SSE interface methods exist', async (t) => {
     await reply.sse.send({ data: 'test' })
   })
 
-  await fastify.listen({ port: 0 })
-
   const response = await fastify.inject({
     method: 'GET',
     url: '/events',
@@ -180,8 +172,6 @@ test('error handling in async iterator', async (t) => {
       await reply.sse.send({ data: 'error handled' })
     }
   })
-
-  await fastify.listen({ port: 0 })
 
   const response = await fastify.inject({
     method: 'GET',

--- a/test/send-headers.test.js
+++ b/test/send-headers.test.js
@@ -1,0 +1,263 @@
+'use strict'
+
+const { test } = require('node:test')
+const { strict: assert } = require('node:assert')
+const Fastify = require('fastify')
+const fastifySSE = require('../index.js')
+
+test('reply.sse.sendHeaders() should send headers manually', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    reply.header('X-Manual-Header', 'manual-value')
+    reply.header('X-Custom-ID', '12345')
+
+    // Manually call sendHeaders before sending any data
+    reply.sse.sendHeaders()
+
+    await reply.sse.send({ data: 'hello after manual headers' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: 'text/event-stream'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['x-manual-header'], 'manual-value')
+  assert.strictEqual(response.headers['x-custom-id'], '12345')
+
+  const body = response.body
+  assert.ok(body.includes('data: "hello after manual headers"'))
+})
+
+test('reply.sse.sendHeaders() should be idempotent', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    reply.header('X-Idempotent-Test', 'test-value')
+
+    // Call sendHeaders multiple times - should be safe
+    reply.sse.sendHeaders()
+    reply.sse.sendHeaders()
+    reply.sse.sendHeaders()
+
+    await reply.sse.send({ data: 'message after multiple sendHeaders calls' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: 'text/event-stream'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['x-idempotent-test'], 'test-value')
+
+  const body = response.body
+  assert.ok(body.includes('data: "message after multiple sendHeaders calls"'))
+})
+
+test('reply.sse.sendHeaders() should transfer all reply headers to raw response', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    // Set various types of headers
+    reply.header('X-Single-Header', 'single-value')
+    reply.headers({
+      'X-Multi-Header-1': 'multi1',
+      'X-Multi-Header-2': 'multi2'
+    })
+    reply.type('text/event-stream')
+
+    // Manually send headers
+    reply.sse.sendHeaders()
+
+    // Set more headers after sendHeaders (these won't be sent)
+    reply.header('X-After-Headers', 'after-value')
+
+    await reply.sse.send({ data: 'test' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: 'text/event-stream'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+
+  // Headers set before sendHeaders() should be present
+  assert.strictEqual(response.headers['x-single-header'], 'single-value')
+  assert.strictEqual(response.headers['x-multi-header-1'], 'multi1')
+  assert.strictEqual(response.headers['x-multi-header-2'], 'multi2')
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+
+  // Headers set after sendHeaders() should NOT be present
+  assert.strictEqual(response.headers['x-after-headers'], undefined)
+})
+
+test('reply.sse.sendHeaders() should work with preHandler hooks', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', {
+    sse: true,
+    preHandler: async (request, reply) => {
+      reply.header('X-PreHandler-Header', 'prehandler-value')
+    }
+  }, async (request, reply) => {
+    reply.header('X-Handler-Header', 'handler-value')
+
+    // Manually send headers
+    reply.sse.sendHeaders()
+
+    await reply.sse.send({ data: 'prehandler test' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: 'text/event-stream'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['x-prehandler-header'], 'prehandler-value')
+  assert.strictEqual(response.headers['x-handler-header'], 'handler-value')
+
+  const body = response.body
+  assert.ok(body.includes('data: "prehandler test"'))
+})
+
+test('reply.sse.sendHeaders() should preserve default SSE headers', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    // Call sendHeaders without setting any custom headers
+    reply.sse.sendHeaders()
+
+    await reply.sse.send({ data: 'default headers preserved' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: 'text/event-stream'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+
+  // Default SSE headers should still be present
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+  assert.strictEqual(response.headers['cache-control'], 'no-cache')
+  assert.strictEqual(response.headers['connection'], 'keep-alive')
+  assert.strictEqual(response.headers['x-accel-buffering'], 'no')
+})
+
+test('headers should still work when sendHeaders() is not called manually', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    reply.header('X-Auto-Header', 'auto-value')
+
+    // Don't call sendHeaders manually - should be called automatically
+    await reply.sse.send({ data: 'automatic headers' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: 'text/event-stream'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['x-auto-header'], 'auto-value')
+
+  const body = response.body
+  assert.ok(body.includes('data: "automatic headers"'))
+})
+
+test('reply.sse.sendHeaders() should work with keepAlive()', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    reply.header('X-KeepAlive-Header', 'keepalive-value')
+
+    reply.sse.sendHeaders()
+    reply.sse.keepAlive()
+
+    // Send a message after headers are sent
+    setTimeout(async () => {
+      await reply.sse.send({ data: 'delayed message' })
+      reply.sse.close()
+    }, 50)
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: 'text/event-stream'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['x-keepalive-header'], 'keepalive-value')
+
+  const body = response.body
+  assert.ok(body.includes('data: "delayed message"'))
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -98,6 +98,15 @@ export interface SSEReplyInterface {
    * Check if the connection is still active
    */
   readonly isConnected: boolean
+
+  /**
+   * Send HTTP headers for the SSE response if not already sent.
+   * This method ensures headers set via reply.header() are transferred
+   * to the raw response before calling writeHead(200).
+   * Called automatically before the first SSE data is sent, but can
+   * also be called manually if needed.
+   */
+  sendHeaders(): void
 }
 
 declare const fastifySSE: FastifyPluginAsync<SSEPluginOptions>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -100,6 +100,11 @@ export interface SSEReplyInterface {
   readonly isConnected: boolean
 
   /**
+   * Check if the connection should be kept alive after handler completion
+   */
+  readonly shouldKeepAlive: boolean
+
+  /**
    * Send HTTP headers for the SSE response if not already sent.
    * This method ensures headers set via reply.header() are transferred
    * to the raw response before calling writeHead(200).


### PR DESCRIPTION
Add public sendHeaders() method for manual header control in SSE responses.