### PR TITLE
fix: review exports for ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -457,3 +457,5 @@ module.exports = fp(fastifySSE, {
   fastify: '5.x',
   name: '@fastify/sse'
 })
+module.exports.default = fastifySSE
+module.exports.fastifySSE = fastifySSE

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "types": "types/index.d.ts",
   "scripts": {
-    "test": "npm run test:unit && npm run test:typescript",
+    "test": "npm run test:unit && npm run test:typescript && npm run test:attw",
     "test:unit": "node --test",
     "test:typescript": "tsd",
+    "test:attw": "attw --pack .",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -38,6 +39,7 @@
     "fastify-plugin": "^5.0.0"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.2",
     "@types/node": "^25.0.3",
     "eslint": "^9.0.0",
     "fastify": "^5.0.0",

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { test } = require('node:test')
+const { strict: assert } = require('node:assert')
+const Fastify = require('fastify')
+
+async function runTest (SSE, t) {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(SSE)
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello world' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: 'text/event-stream'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+  assert.strictEqual(response.headers['cache-control'], 'no-cache')
+  assert.strictEqual(response.headers.connection, 'keep-alive')
+
+  const { body: responseBody } = response
+  assert.ok(responseBody.includes('data: "hello world"'))
+  assert.ok(responseBody.endsWith('\n\n'))
+}
+
+test('module import', async (t) => {
+  const fastifySSE = require('../index.js')
+  await runTest(fastifySSE, t)
+})
+
+test('default import', async (t) => {
+  const { default: fastifySSE } = require('../index.js')
+  await runTest(fastifySSE, t)
+})
+
+test('named import', async (t) => {
+  const { fastifySSE } = require('../index.js')
+  await runTest(fastifySSE, t)
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
-import { Readable } from 'stream'
 import { FastifyPluginAsync } from 'fastify'
+import { Readable } from 'stream'
 
 declare module 'fastify' {
   interface FastifyReply {
@@ -114,6 +114,6 @@ export interface SSEReplyInterface {
   sendHeaders(): void
 }
 
-declare const fastifySSE: FastifyPluginAsync<SSEPluginOptions>
+export declare const fastifySSE: FastifyPluginAsync<SSEPluginOptions>
 
 export default fastifySSE


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR fixes #14.
Review the export in the `index.js` file. Align the export in the `types/index.d.ts`.
Enable [arethetypeswrong CLI](https://github.com/arethetypeswrong/arethetypeswrong.github.io/tree/main/packages/cli) to check the TypeScript exports.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
