### PR TITLE
feat: Make ACCEPTS header parsing follow specification more closely

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,27 +57,39 @@ await fastify.register(require('@fastify/sse'), {
   heartbeatInterval: 30000,
 
   // Optional: default serializer (default: JSON.stringify)
-  serializer: (data) => JSON.stringify(data),
-
-  // Optional: require an explicit `text/event-stream` token in the Accept
-  // header. Default (false) is spec-compliant — `*/*`, `text/*`, and missing
-  // Accept all admit SSE. See "Accept-Header Negotiation" below.
-  strictAccept: false
+  serializer: (data) => JSON.stringify(data)
 })
 ```
 
 ### Route Configuration
 
-```js
-// Enable SSE for a route
-fastify.get('/events', { sse: true }, handler)
+Routes opt into SSE handling by setting the `sse` field. There are three
+forms, each describing what the route serves:
 
-// With options
+```js
+// SSE-only route: handler always streams. Clients that explicitly refuse
+// SSE (e.g. `Accept: application/json`) receive 406 Not Acceptable.
+// Ambiguous Accept headers (*/*, text/*, missing) admit SSE per RFC 9110.
+fastify.get('/events', { sse: 'only' }, handler)
+
+// Dual-mode route: the same handler serves both SSE and non-SSE clients.
+// Only an explicit `text/event-stream` token routes to SSE; everything
+// else falls through to the handler with `reply.sse` undefined, so the
+// handler is expected to produce a non-SSE response in that branch.
+fastify.get('/data', { sse: 'dual' }, handler)
+
+// Back-compat: `sse: true` behaves like `'dual'` for routing. If the
+// handler is actually SSE-only and trips a TypeError on `reply.sse`
+// because of a wildcard Accept, the plugin rethrows with a clearer error
+// nudging you toward `sse: 'only'`.
+fastify.get('/legacy', { sse: true }, handler)
+
+// Object form (supports per-route options):
 fastify.get('/events', {
   sse: {
+    kind: 'only',                // 'only' | 'dual' — omit for back-compat
     heartbeat: false,            // Disable heartbeat for this route
-    serializer: customSerializer, // Custom serializer for this route
-    strictAccept: true           // Per-route opt-out of the SSE-wins default
+    serializer: customSerializer // Custom serializer for this route
   }
 }, handler)
 ```
@@ -250,56 +262,37 @@ fastify.get('/events', { sse: true }, async (request, reply) => {
 
 ### Accept-Header Negotiation
 
-The plugin decides whether to serve a request as SSE by parsing the `Accept`
-header per [RFC 9110 §12.5.1](https://www.rfc-editor.org/rfc/rfc9110#name-accept).
-By default, SSE is served when the client's Accept header admits
-`text/event-stream`, which is true for any of:
+The plugin parses the `Accept` header per [RFC 9110 §12.5.1](https://www.rfc-editor.org/rfc/rfc9110#name-accept)
+to decide whether to serve a request as SSE. The decision depends on the
+route's declared kind:
 
-- A missing or empty `Accept` header (any media type is acceptable).
-- `Accept: */*` — typical for `curl`, Postman, and `fetch()` defaults.
-- `Accept: text/*`.
-- `Accept: text/event-stream` (with quality value > 0).
+| Route kind     | Accept header              | Behavior                |
+|----------------|----------------------------|-------------------------|
+| `sse: 'only'`  | `text/event-stream`        | SSE                     |
+| `sse: 'only'`  | `*/*`, `text/*`, missing   | SSE                     |
+| `sse: 'only'`  | `application/json` etc.    | **406 Not Acceptable**  |
+| `sse: 'only'`  | `…, text/event-stream;q=0` | **406 Not Acceptable**  |
+| `sse: 'dual'`  | `text/event-stream`        | SSE branch              |
+| `sse: 'dual'`  | `*/*`, `text/*`, missing   | Non-SSE branch          |
+| `sse: 'dual'`  | `application/json`         | Non-SSE branch          |
+| `sse: true`    | (same routing as `'dual'`) | + clearer error on misuse |
 
-If the most specific matching range has `q=0` (e.g.
-`Accept: */*, text/event-stream;q=0`) the client has explicitly refused SSE
-and the plugin falls through to the regular handler.
+In short: explicit `text/event-stream` always routes to SSE; ambiguous
+wildcards route to SSE only when you've declared the route SSE-only.
+This keeps `curl`, `fetch()`, and Postman defaults working with SSE-only
+endpoints while preserving the dual-mode pattern's expectation that a
+wildcard prefers the richer non-SSE representation.
 
-**Opting out of the SSE-wins default.** Set `strictAccept: true` (at the
-plugin level or per route) to require an explicit `text/event-stream` token
-in the Accept header. Ambiguous headers (`*/*`, `text/*`, missing) will
-then fall through to the regular handler:
+### Fallback to Regular Responses (`sse: 'dual'`)
 
-```js
-// Plugin-wide opt-out
-await fastify.register(require('@fastify/sse'), { strictAccept: true })
-
-// Per-route opt-out
-fastify.get('/events', {
-  sse: { strictAccept: true }
-}, handler)
-```
-
-You can call the gate yourself via the exported `clientAcceptsSSE` helper
-if you need to make the same decision elsewhere:
+Dual-mode routes serve both SSE and non-SSE clients from a single
+handler. The plugin attaches `reply.sse` only when the client explicitly
+requested `text/event-stream`; otherwise the handler is invoked without
+`reply.sse` and is expected to produce a normal response. Branch on its
+presence:
 
 ```js
-const { clientAcceptsSSE } = require('@fastify/sse')
-clientAcceptsSSE('*/*')                       // true
-clientAcceptsSSE('application/json')          // false
-clientAcceptsSSE('*/*', { strict: true })     // false
-clientAcceptsSSE('text/event-stream', { strict: true }) // true
-```
-
-### Fallback to Regular Responses
-
-When `{ sse: true }` is set on a route, the plugin attaches `reply.sse` only
-for clients that admit `text/event-stream`. For clients that explicitly
-request a different media type (e.g. `Accept: application/json`), the route
-handler is invoked without `reply.sse`. Branch on its presence to serve a
-non-SSE fallback:
-
-```js
-fastify.get('/data', { sse: true }, async (request, reply) => {
+fastify.get('/data', { sse: 'dual' }, async (request, reply) => {
   const data = await getData()
 
   if (reply.sse) {
@@ -310,6 +303,24 @@ fastify.get('/data', { sse: true }, async (request, reply) => {
     return { data }
   }
 })
+```
+
+The SSE-specific response headers (`Content-Type: text/event-stream`
+etc.) are not committed until the first `reply.sse.send()` /
+`reply.sse.stream()` call, so a handler that decorates `reply.sse` but
+then returns a plain value falls through to Fastify's normal
+serialization path without corrupting the response.
+
+### Helper: `clientAcceptsSSE`
+
+Use the exported helper if you need to make the same decision elsewhere:
+
+```js
+const { clientAcceptsSSE } = require('@fastify/sse')
+clientAcceptsSSE('*/*')                                  // true
+clientAcceptsSSE('application/json')                     // false
+clientAcceptsSSE('*/*', { strict: true })                // false
+clientAcceptsSSE('text/event-stream', { strict: true })  // true
 ```
 
 ### Error Handling

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ fastify.get('/data', { sse: 'dual' }, handler)
 
 // Back-compat: `sse: true` behaves like `'dual'` for routing. If the
 // handler is actually SSE-only and trips a TypeError on `reply.sse`
-// because of a wildcard Accept, the plugin rethrows with a clearer error
-// nudging you toward `sse: 'only'`.
+// because of a wildcard Accept, the plugin rethrows with a message
+// that names `sse: 'only'` as the fix.
 fastify.get('/legacy', { sse: true }, handler)
 
 // Object form (supports per-route options):
@@ -275,7 +275,7 @@ route's declared kind:
 | `sse: 'dual'`  | `text/event-stream`        | SSE branch              |
 | `sse: 'dual'`  | `*/*`, `text/*`, missing   | Non-SSE branch          |
 | `sse: 'dual'`  | `application/json`         | Non-SSE branch          |
-| `sse: true`    | (same routing as `'dual'`) | + clearer error on misuse |
+| `sse: true`    | (same routing as `'dual'`) | + explanatory error on misuse |
 
 In short: explicit `text/event-stream` always routes to SSE; ambiguous
 wildcards route to SSE only when you've declared the route SSE-only.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ await fastify.register(require('@fastify/sse'), {
   heartbeatInterval: 30000,
 
   // Optional: default serializer (default: JSON.stringify)
-  serializer: (data) => JSON.stringify(data)
+  serializer: (data) => JSON.stringify(data),
+
+  // Optional: require an explicit `text/event-stream` token in the Accept
+  // header. Default (false) is spec-compliant — `*/*`, `text/*`, and missing
+  // Accept all admit SSE. See "Accept-Header Negotiation" below.
+  strictAccept: false
 })
 ```
 
@@ -70,8 +75,9 @@ fastify.get('/events', { sse: true }, handler)
 // With options
 fastify.get('/events', {
   sse: {
-    heartbeat: false,           // Disable heartbeat for this route
-    serializer: customSerializer // Custom serializer for this route
+    heartbeat: false,            // Disable heartbeat for this route
+    serializer: customSerializer, // Custom serializer for this route
+    strictAccept: true           // Per-route opt-out of the SSE-wins default
   }
 }, handler)
 ```
@@ -242,20 +248,65 @@ fastify.get('/events', { sse: true }, async (request, reply) => {
 
 ## Advanced Usage
 
+### Accept-Header Negotiation
+
+The plugin decides whether to serve a request as SSE by parsing the `Accept`
+header per [RFC 9110 §12.5.1](https://www.rfc-editor.org/rfc/rfc9110#name-accept).
+By default, SSE is served when the client's Accept header admits
+`text/event-stream`, which is true for any of:
+
+- A missing or empty `Accept` header (any media type is acceptable).
+- `Accept: */*` — typical for `curl`, Postman, and `fetch()` defaults.
+- `Accept: text/*`.
+- `Accept: text/event-stream` (with quality value > 0).
+
+If the most specific matching range has `q=0` (e.g.
+`Accept: */*, text/event-stream;q=0`) the client has explicitly refused SSE
+and the plugin falls through to the regular handler.
+
+**Opting out of the SSE-wins default.** Set `strictAccept: true` (at the
+plugin level or per route) to require an explicit `text/event-stream` token
+in the Accept header. Ambiguous headers (`*/*`, `text/*`, missing) will
+then fall through to the regular handler:
+
+```js
+// Plugin-wide opt-out
+await fastify.register(require('@fastify/sse'), { strictAccept: true })
+
+// Per-route opt-out
+fastify.get('/events', {
+  sse: { strictAccept: true }
+}, handler)
+```
+
+You can call the gate yourself via the exported `clientAcceptsSSE` helper
+if you need to make the same decision elsewhere:
+
+```js
+const { clientAcceptsSSE } = require('@fastify/sse')
+clientAcceptsSSE('*/*')                       // true
+clientAcceptsSSE('application/json')          // false
+clientAcceptsSSE('*/*', { strict: true })     // false
+clientAcceptsSSE('text/event-stream', { strict: true }) // true
+```
+
 ### Fallback to Regular Responses
 
-Routes with `{ sse: true }` automatically fall back to regular handlers when the client doesn't request SSE:
+When `{ sse: true }` is set on a route, the plugin attaches `reply.sse` only
+for clients that admit `text/event-stream`. For clients that explicitly
+request a different media type (e.g. `Accept: application/json`), the route
+handler is invoked without `reply.sse`. Branch on its presence to serve a
+non-SSE fallback:
 
 ```js
 fastify.get('/data', { sse: true }, async (request, reply) => {
   const data = await getData()
 
-  // Check if this is an SSE request
-  if (request.headers.accept?.includes('text/event-stream')) {
-    // SSE client - stream the data
+  if (reply.sse) {
+    // SSE client — stream the data
     await reply.sse.send({ data })
   } else {
-    // Regular client - return JSON
+    // Regular client — return JSON
     return { data }
   }
 })

--- a/README.md
+++ b/README.md
@@ -311,17 +311,6 @@ etc.) are not committed until the first `reply.sse.send()` /
 then returns a plain value falls through to Fastify's normal
 serialization path without corrupting the response.
 
-### Helper: `clientAcceptsSSE`
-
-Use the exported helper if you need to make the same decision elsewhere:
-
-```js
-const { clientAcceptsSSE } = require('@fastify/sse')
-clientAcceptsSSE('*/*')                                  // true
-clientAcceptsSSE('application/json')                     // false
-clientAcceptsSSE('*/*', { strict: true })                // false
-clientAcceptsSSE('text/event-stream', { strict: true })  // true
-```
 
 ### Error Handling
 

--- a/index.js
+++ b/index.js
@@ -526,10 +526,11 @@ async function fastifySSE (fastify, opts) {
       //             Strict gate: only an explicit `text/event-stream` token
       //             admits SSE; everything else falls through to the
       //             handler, which is expected to serve a non-SSE response.
-      //   'legacy' — `sse: true` back-compat. Same routing as 'dual', plus
-      //              a clearer error if the fallback handler tries to use
-      //              `reply.sse` (signals "you wanted SSE-only — use
-      //              `sse: 'only'`").
+      //   'legacy' — `sse: true` back-compat. Same routing as 'dual'. If
+      //              the fallback handler then tries to use `reply.sse`
+      //              (which is undefined because the gate refused), the
+      //              plugin rethrows with a message that names
+      //              `sse: 'only'` as the likely fix.
       if (kind === 'only') {
         if (!clientAcceptsSSE(acceptHeader)) {
           return reply.code(406).type('application/json').send({

--- a/index.js
+++ b/index.js
@@ -1,15 +1,81 @@
 'use strict'
 
 const fp = require('fastify-plugin')
+const createError = require('@fastify/error')
 const { Readable, Transform } = require('stream')
 const { pipeline } = require('stream/promises')
+
+const FST_ERR_SSE_UNKNOWN_KIND = createError(
+  'FST_ERR_SSE_UNKNOWN_KIND',
+  "@fastify/sse: unknown sse kind '%s'. Use 'only' (SSE-only route), 'dual' (route serves both SSE and non-SSE), or omit for back-compat."
+)
+
+const FST_ERR_SSE_INVALID_OPTION = createError(
+  'FST_ERR_SSE_INVALID_OPTION',
+  "@fastify/sse: unsupported value for route option 'sse': %s. Use true, 'dual', 'only', or an options object."
+)
+
+const FST_ERR_SSE_LEGACY_MISUSE = createError(
+  'FST_ERR_SSE_LEGACY_MISUSE',
+  "@fastify/sse: route registered with { sse: true } received Accept '%s' (no explicit 'text/event-stream') " +
+  'and the handler then tried to use reply.sse. If this route only serves SSE, ' +
+  "register it with { sse: 'only' } so ambiguous Accept headers admit SSE per " +
+  'RFC 9110. If it serves both SSE and a non-SSE representation, register with ' +
+  "{ sse: 'dual' } and branch on the Accept header in the handler. " +
+  '(Underlying error: %s)'
+)
+
+const FST_ERR_SSE_CONNECTION_CLOSED = createError(
+  'FST_ERR_SSE_CONNECTION_CLOSED',
+  'SSE connection is closed'
+)
+
+// Character codes used by the Accept-header scanner. Hoisted to module scope
+// so V8 treats them as constants and the tight loops below stay monomorphic.
+const CC_SP = 32
+const CC_HT = 9
+const CC_COMMA = 44
+const CC_SEMI = 59
+const CC_EQ = 61
+const CC_DOT = 46
+const CC_ZERO = 48
+const CC_LOWER_Q = 113
+const CC_UPPER_Q = 81
+
+function ciEqualsAt (s, start, end, lower) {
+  if (end - start !== lower.length) return false
+  for (let j = 0; j < lower.length; j++) {
+    let c = s.charCodeAt(start + j)
+    if (c >= 65 && c <= 90) c |= 32
+    if (c !== lower.charCodeAt(j)) return false
+  }
+  return true
+}
+
+function isQValueZero (s, start, end) {
+  if (end <= start) return false
+  if (s.charCodeAt(start) !== CC_ZERO) return false
+  let i = start + 1
+  if (i < end && s.charCodeAt(i) === CC_DOT) {
+    i++
+    while (i < end) {
+      if (s.charCodeAt(i) !== CC_ZERO) return false
+      i++
+    }
+  }
+  return i === end
+}
 
 /**
  * Determine whether the client's Accept header admits `text/event-stream`.
  *
  * Implements the RFC 9110 §12.5.1 precedence model for the media ranges that
  * are relevant to SSE — `text/event-stream`, `text/*`, and `*\/*`. Other
- * media-type parameters are ignored; only the `q` parameter is honored.
+ * media-type parameters are ignored; only the `q` parameter is honored, and
+ * only the binary distinction `q=0` (explicit refuse) vs `q>0` (admit) is
+ * preserved. Fractional qvalues like `q=0.5` are treated identically to
+ * `q=1`: observably equivalent here because the function picks the winning
+ * media range by specificity, not by comparing fractional qvalues.
  *
  * Default (lenient) returns true when the header is missing, empty, or
  * contains a matching range with quality > 0. The most specific matching
@@ -19,49 +85,116 @@ const { pipeline } = require('stream/promises')
  * with quality > 0; ambiguous headers (`*\/*`, `text/*`, missing) return
  * false in strict mode.
  *
- * Quality values outside [0, 1] are ignored and the entry's quality defaults
- * to 1 (the spec default when no qvalue is present).
+ * Hot paths (`text/event-stream`, `*\/*`, `text/*`) short-circuit before any
+ * scanning, so the common case is a single string-equality compare.
  *
  * @param {string|undefined} acceptHeader
  * @param {{ strict?: boolean }} [options]
  * @returns {boolean}
  */
 function clientAcceptsSSE (acceptHeader, options) {
-  const strict = options?.strict === true
+  const strict = options !== undefined && options.strict === true
   if (!acceptHeader) return !strict
 
-  let bestSpecificity = -1
-  let bestQuality = 0
+  // Hot path: the literal values that EventSource and common HTTP clients
+  // actually emit. Caught with a single ===, no allocation.
+  if (acceptHeader === 'text/event-stream') return true
+  if (!strict && (acceptHeader === '*/*' || acceptHeader === 'text/*')) return true
 
-  for (const part of acceptHeader.split(',')) {
-    const [rawType, ...params] = part.split(';')
-    const type = rawType.trim().toLowerCase()
+  // Slow path: walk the header in place via charCodeAt. No .split(),
+  // no .toLowerCase(), no .trim(), no substrings allocated.
+  const len = acceptHeader.length
+  let bestSpec = -1
+  let bestRefused = false
+  let i = 0
 
-    let specificity
-    if (type === 'text/event-stream') specificity = 3
-    else if (!strict && type === 'text/*') specificity = 2
-    else if (!strict && type === '*/*') specificity = 1
-    else continue
+  while (i < len) {
+    while (i < len) {
+      const c = acceptHeader.charCodeAt(i)
+      if (c !== CC_SP && c !== CC_HT) break
+      i++
+    }
 
-    let quality = 1
-    for (const p of params) {
-      const eq = p.indexOf('=')
-      if (eq === -1) continue
-      const key = p.slice(0, eq).trim().toLowerCase()
-      if (key !== 'q') continue
-      const parsed = Number.parseFloat(p.slice(eq + 1).trim())
-      if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) {
-        quality = parsed
+    const typeStart = i
+    while (i < len) {
+      const c = acceptHeader.charCodeAt(i)
+      if (c === CC_SEMI || c === CC_COMMA) break
+      i++
+    }
+    let typeEnd = i
+    while (typeEnd > typeStart) {
+      const c = acceptHeader.charCodeAt(typeEnd - 1)
+      if (c !== CC_SP && c !== CC_HT) break
+      typeEnd--
+    }
+
+    let spec = -1
+    if (ciEqualsAt(acceptHeader, typeStart, typeEnd, 'text/event-stream')) spec = 3
+    else if (!strict && ciEqualsAt(acceptHeader, typeStart, typeEnd, 'text/*')) spec = 2
+    else if (!strict && ciEqualsAt(acceptHeader, typeStart, typeEnd, '*/*')) spec = 1
+
+    let refused = false
+    if (spec === -1) {
+      // Non-matching entry: skip its parameters in one jump.
+      while (i < len && acceptHeader.charCodeAt(i) !== CC_COMMA) i++
+    } else {
+      // Spec note: per RFC 9110 §5.6.6, `parameter = parameter-name "="
+      // parameter-value` permits no OWS inside the parameter — only around
+      // the `;` separator. We honor the OWS-around-`;` case (which browsers
+      // emit as `; q=0.8`) but do not handle OWS adjacent to `=` or
+      // trailing OWS on the value/key (which would be malformed input
+      // anyway). Node's HTTP parser also strips leading + trailing OWS
+      // from the whole header value, so the only WS we see in production
+      // is OWS after `,` and after `;`.
+      while (i < len && acceptHeader.charCodeAt(i) === CC_SEMI) {
+        i++
+        while (i < len) {
+          const c = acceptHeader.charCodeAt(i)
+          if (c !== CC_SP && c !== CC_HT) break
+          i++
+        }
+        const keyStart = i
+        while (i < len) {
+          const c = acceptHeader.charCodeAt(i)
+          if (c === CC_EQ || c === CC_SEMI || c === CC_COMMA) break
+          i++
+        }
+        const keyEnd = i
+
+        if (i < len && acceptHeader.charCodeAt(i) === CC_EQ) {
+          i++
+          const valStart = i
+          while (i < len) {
+            const c = acceptHeader.charCodeAt(i)
+            if (c === CC_SEMI || c === CC_COMMA) break
+            i++
+          }
+          const valEnd = i
+
+          if (keyEnd - keyStart === 1) {
+            const kc = acceptHeader.charCodeAt(keyStart)
+            if ((kc === CC_LOWER_Q || kc === CC_UPPER_Q) &&
+                isQValueZero(acceptHeader, valStart, valEnd)) {
+              refused = true
+            }
+          }
+        }
       }
     }
 
-    if (specificity > bestSpecificity) {
-      bestSpecificity = specificity
-      bestQuality = quality
+    // text/event-stream with a non-refused qvalue has the maximum
+    // specificity; nothing later in the list can outrank it.
+    if (spec === 3 && !refused) return true
+
+    if (spec > bestSpec) {
+      bestSpec = spec
+      bestRefused = refused
     }
+
+    if (i < len && acceptHeader.charCodeAt(i) === CC_COMMA) i++
   }
 
-  return bestSpecificity >= 0 && bestQuality > 0
+  return bestSpec >= 0 && !bestRefused
 }
 
 /**
@@ -86,17 +219,11 @@ function resolveSSEConfig (sseField) {
   if (typeof sseField === 'object' && sseField !== null) {
     const kind = sseField.kind ?? 'legacy'
     if (kind !== 'legacy' && kind !== 'dual' && kind !== 'only') {
-      throw new Error(
-        `@fastify/sse: unknown sse kind '${kind}'. Use 'only' (SSE-only route), ` +
-        '\'dual\' (route serves both SSE and non-SSE), or omit for back-compat.'
-      )
+      throw new FST_ERR_SSE_UNKNOWN_KIND(kind)
     }
     return { kind, options: sseField }
   }
-  throw new Error(
-    `@fastify/sse: unsupported value for route option 'sse': ${JSON.stringify(sseField)}. ` +
-    'Use true, \'dual\', \'only\', or an options object.'
-  )
+  throw new FST_ERR_SSE_INVALID_OPTION(JSON.stringify(sseField))
 }
 
 const MISSING_SSE_ERROR_PATTERN = /Cannot read prop(?:erties)? of undefined.*'(?:send|stream|keepAlive|close|sendHeaders|replay|onClose)'/
@@ -319,7 +446,7 @@ class SSEContext {
    */
   async send (source) {
     if (!this.#isConnected) {
-      throw new Error('SSE connection is closed')
+      throw new FST_ERR_SSE_CONNECTION_CLOSED()
     }
 
     // Handle single message
@@ -371,7 +498,7 @@ class SSEContext {
    */
   stream () {
     if (!this.#isConnected) {
-      throw new Error('SSE connection is closed')
+      throw new FST_ERR_SSE_CONNECTION_CLOSED()
     }
 
     const transform = createSSETransformStream({ serializer: this.serializer })
@@ -548,15 +675,7 @@ async function fastifySSE (fastify, opts) {
               return await originalHandler.call(this, request, reply)
             } catch (err) {
               if (err instanceof TypeError && MISSING_SSE_ERROR_PATTERN.test(err.message)) {
-                throw new Error(
-                  '@fastify/sse: route registered with { sse: true } received ' +
-                  `Accept '${acceptHeader || '<missing>'}' (no explicit 'text/event-stream') ` +
-                  'and the handler then tried to use reply.sse. If this route only serves SSE, ' +
-                  'register it with { sse: \'only\' } so ambiguous Accept headers admit SSE per ' +
-                  'RFC 9110. If it serves both SSE and a non-SSE representation, register with ' +
-                  '{ sse: \'dual\' } and branch on the Accept header in the handler. ' +
-                  `(Underlying error: ${err.message})`
-                )
+                throw new FST_ERR_SSE_LEGACY_MISUSE(acceptHeader || '<missing>', err.message)
               }
               throw err
             }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,103 @@ const { Readable, Transform } = require('stream')
 const { pipeline } = require('stream/promises')
 
 /**
+ * Determine whether the client's Accept header admits `text/event-stream`.
+ *
+ * Implements the RFC 9110 §12.5.1 precedence model for the media ranges that
+ * are relevant to SSE — `text/event-stream`, `text/*`, and `*\/*`. Other
+ * media-type parameters are ignored; only the `q` parameter is honored.
+ *
+ * Default (lenient) returns true when the header is missing, empty, or
+ * contains a matching range with quality > 0. The most specific matching
+ * range wins, so `*\/*, text/event-stream;q=0` correctly returns false.
+ *
+ * Pass `{ strict: true }` to require an explicit `text/event-stream` token
+ * with quality > 0; ambiguous headers (`*\/*`, `text/*`, missing) return
+ * false in strict mode.
+ *
+ * Quality values outside [0, 1] are ignored and the entry's quality defaults
+ * to 1 (the spec default when no qvalue is present).
+ *
+ * @param {string|undefined} acceptHeader
+ * @param {{ strict?: boolean }} [options]
+ * @returns {boolean}
+ */
+function clientAcceptsSSE (acceptHeader, options) {
+  const strict = options?.strict === true
+  if (!acceptHeader) return !strict
+
+  let bestSpecificity = -1
+  let bestQuality = 0
+
+  for (const part of acceptHeader.split(',')) {
+    const [rawType, ...params] = part.split(';')
+    const type = rawType.trim().toLowerCase()
+
+    let specificity
+    if (type === 'text/event-stream') specificity = 3
+    else if (!strict && type === 'text/*') specificity = 2
+    else if (!strict && type === '*/*') specificity = 1
+    else continue
+
+    let quality = 1
+    for (const p of params) {
+      const eq = p.indexOf('=')
+      if (eq === -1) continue
+      const key = p.slice(0, eq).trim().toLowerCase()
+      if (key !== 'q') continue
+      const parsed = Number.parseFloat(p.slice(eq + 1).trim())
+      if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) {
+        quality = parsed
+      }
+    }
+
+    if (specificity > bestSpecificity) {
+      bestSpecificity = specificity
+      bestQuality = quality
+    }
+  }
+
+  return bestSpecificity >= 0 && bestQuality > 0
+}
+
+/**
+ * Resolve the `sse` field on route options into a normalized shape.
+ *
+ *   - `sse: true`     → kind 'legacy' (back-compat, strict gate + clearer
+ *                       error if the handler tries to use reply.sse on the
+ *                       fallback path)
+ *   - `sse: 'dual'`   → kind 'dual'  (explicit dual-mode: strict gate, the
+ *                       handler is expected to serve a non-SSE response when
+ *                       reply.sse is undefined)
+ *   - `sse: 'only'`   → kind 'only'  (SSE-only: lenient gate, returns 406
+ *                       Not Acceptable to clients that explicitly refuse SSE)
+ *   - `sse: { ... }`  → object form; same kinds via `kind: 'dual' | 'only'`,
+ *                       or `kind` omitted = 'legacy' for back-compat with
+ *                       existing `{ heartbeat, serializer, ... }` shapes
+ */
+function resolveSSEConfig (sseField) {
+  if (sseField === true) return { kind: 'legacy', options: {} }
+  if (sseField === 'dual') return { kind: 'dual', options: {} }
+  if (sseField === 'only') return { kind: 'only', options: {} }
+  if (typeof sseField === 'object' && sseField !== null) {
+    const kind = sseField.kind ?? 'legacy'
+    if (kind !== 'legacy' && kind !== 'dual' && kind !== 'only') {
+      throw new Error(
+        `@fastify/sse: unknown sse kind '${kind}'. Use 'only' (SSE-only route), ` +
+        '\'dual\' (route serves both SSE and non-SSE), or omit for back-compat.'
+      )
+    }
+    return { kind, options: sseField }
+  }
+  throw new Error(
+    `@fastify/sse: unsupported value for route option 'sse': ${JSON.stringify(sseField)}. ` +
+    'Use true, \'dual\', \'only\', or an options object.'
+  )
+}
+
+const MISSING_SSE_ERROR_PATTERN = /Cannot read prop(?:erties)? of undefined.*'(?:send|stream|keepAlive|close|sendHeaders|replay|onClose)'/
+
+/**
  * Format an SSE message according to the specification
  * @param {Object|string|Buffer} message - The message to format
  * @param {Function} serializer - Function to serialize data
@@ -152,13 +249,19 @@ class SSEContext {
   /**
    * Closes the SSE connection and performs cleanup.
    * Safe to call multiple times.
+   *
+   * If no SSE data was ever written (i.e., headers were never committed as
+   * SSE), the raw response is left open so Fastify can serialize the
+   * handler's return value normally.
    */
   close () {
     if (!this.#isConnected) return
 
     this.#isConnected = false
     this.cleanup()
-    this.reply.raw.end()
+    if (this.#headersSent) {
+      this.reply.raw.end()
+    }
   }
 
   /**
@@ -182,14 +285,22 @@ class SSEContext {
 
   /**
    * Sends HTTP headers for the SSE response if not already sent.
-   * This method ensures headers set via reply.header() are transferred
-   * to the raw response before calling writeHead(200).
-   * Called automatically before the first SSE data is sent, but can
-   * also be called manually if needed.
+   * Applies the SSE-specific response headers, transfers any headers set
+   * via reply.header(), and calls writeHead(200). Called automatically
+   * before the first SSE data is sent, but can also be called manually.
+   *
+   * Until this fires, the response is not yet committed as SSE — a handler
+   * that never writes SSE data will return through Fastify's normal
+   * serialization path.
    */
   sendHeaders () {
     if (!this.#headersSent) {
-      // Get any headers set via reply.header() and transfer to raw response
+      this.reply.raw.setHeader('Content-Type', 'text/event-stream')
+      this.reply.raw.setHeader('Cache-Control', 'no-cache')
+      this.reply.raw.setHeader('Connection', 'keep-alive')
+      this.reply.raw.setHeader('X-Accel-Buffering', 'no') // Disable Nginx buffering
+
+      // Transfer headers set via reply.header() to the raw response
       const replyHeaders = this.reply.getHeaders()
       for (const [name, value] of Object.entries(replyHeaders)) {
         this.reply.raw.setHeader(name, value)
@@ -392,105 +503,70 @@ class SSEContext {
   }
 }
 
-/**
- * Determine whether the client's Accept header admits `text/event-stream`.
- *
- * Implements the RFC 9110 §12.5.1 precedence model for the media ranges that
- * are relevant to SSE — `text/event-stream`, `text/*`, and `*\/*`. Other
- * media-type parameters are ignored; only the `q` parameter is honored.
- *
- * Default (lenient) behavior returns true when:
- *   - Accept is missing or empty (any media type is acceptable),
- *   - `text/event-stream`, `text/*`, or `*\/*` appears with a quality > 0
- *     and is the most specific match present in the header.
- *
- * Pass `{ strict: true }` to require an explicit `text/event-stream` token
- * with quality > 0; ambiguous headers (`*\/*`, `text/*`, missing) return
- * false in strict mode.
- *
- * The most specific matching range wins (exact > subtype wildcard > full
- * wildcard), so `*\/*, text/event-stream;q=0` correctly returns false.
- *
- * Quality values outside [0, 1] are ignored and the entry's quality defaults
- * to 1 (the spec default when no qvalue is present).
- *
- * @param {string|undefined} acceptHeader
- * @param {{ strict?: boolean }} [options]
- * @returns {boolean}
- */
-function clientAcceptsSSE (acceptHeader, options) {
-  const strict = options?.strict === true
-  if (!acceptHeader) return !strict
-
-  let bestSpecificity = -1
-  let bestQuality = 0
-
-  for (const part of acceptHeader.split(',')) {
-    const [rawType, ...params] = part.split(';')
-    const type = rawType.trim().toLowerCase()
-
-    let specificity
-    if (type === 'text/event-stream') specificity = 3
-    else if (!strict && type === 'text/*') specificity = 2
-    else if (!strict && type === '*/*') specificity = 1
-    else continue
-
-    let quality = 1
-    for (const p of params) {
-      const eq = p.indexOf('=')
-      if (eq === -1) continue
-      const key = p.slice(0, eq).trim().toLowerCase()
-      if (key !== 'q') continue
-      const parsed = Number.parseFloat(p.slice(eq + 1).trim())
-      // Per RFC 9110, qvalue is in [0, 1]; anything else is invalid and
-      // ignored (the entry's quality stays at the default of 1).
-      if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) {
-        quality = parsed
-      }
-    }
-
-    if (specificity > bestSpecificity) {
-      bestSpecificity = specificity
-      bestQuality = quality
-    }
-  }
-
-  return bestSpecificity >= 0 && bestQuality > 0
-}
-
 async function fastifySSE (fastify, opts) {
   const {
     heartbeatInterval = 30000,
-    serializer = JSON.stringify,
-    strictAccept: pluginStrictAccept = false
+    serializer = JSON.stringify
   } = opts
 
   // Add route-level SSE handler
   fastify.addHook('onRoute', (routeOptions) => {
     if (!routeOptions.sse) return
 
+    const { kind, options: sseOptions } = resolveSSEConfig(routeOptions.sse)
     const originalHandler = routeOptions.handler
-    const sseOptions = typeof routeOptions.sse === 'object' ? routeOptions.sse : {}
-    const strictAccept = sseOptions.strictAccept ?? pluginStrictAccept
 
     routeOptions.handler = async function sseHandler (request, reply) {
-      // Decide whether to handle this request as SSE.
-      //   - Default (strictAccept: false): spec-compliant per RFC 9110 —
-      //     admit SSE for `text/event-stream`, `text/*`, `*\/*`, and missing
-      //     Accept.
-      //   - strictAccept: true — require an explicit `text/event-stream`
-      //     token; ambiguous headers (`*\/*`, `text/*`, missing) fall through.
-      if (!clientAcceptsSSE(request.headers.accept, { strict: strictAccept })) {
-        return await originalHandler.call(this, request, reply)
+      const acceptHeader = request.headers.accept
+
+      // Kind-specific gate.
+      //   'only'  — SSE-only route. Lenient gate: any spec-compliant Accept
+      //             admits SSE. Clients that explicitly refuse SSE get 406.
+      //   'dual'  — Route serves both SSE and non-SSE on the same handler.
+      //             Strict gate: only an explicit `text/event-stream` token
+      //             admits SSE; everything else falls through to the
+      //             handler, which is expected to serve a non-SSE response.
+      //   'legacy' — `sse: true` back-compat. Same routing as 'dual', plus
+      //              a clearer error if the fallback handler tries to use
+      //              `reply.sse` (signals "you wanted SSE-only — use
+      //              `sse: 'only'`").
+      if (kind === 'only') {
+        if (!clientAcceptsSSE(acceptHeader)) {
+          return reply.code(406).type('application/json').send({
+            statusCode: 406,
+            error: 'Not Acceptable',
+            message: "This endpoint only produces 'text/event-stream'."
+          })
+        }
+        // Fall through to SSE setup.
+      } else {
+        // 'dual' or 'legacy'
+        if (!clientAcceptsSSE(acceptHeader, { strict: true })) {
+          if (kind === 'legacy') {
+            try {
+              return await originalHandler.call(this, request, reply)
+            } catch (err) {
+              if (err instanceof TypeError && MISSING_SSE_ERROR_PATTERN.test(err.message)) {
+                throw new Error(
+                  '@fastify/sse: route registered with { sse: true } received ' +
+                  `Accept '${acceptHeader || '<missing>'}' (no explicit 'text/event-stream') ` +
+                  'and the handler then tried to use reply.sse. If this route only serves SSE, ' +
+                  'register it with { sse: \'only\' } so ambiguous Accept headers admit SSE per ' +
+                  'RFC 9110. If it serves both SSE and a non-SSE representation, register with ' +
+                  '{ sse: \'dual\' } and branch on the Accept header in the handler. ' +
+                  `(Underlying error: ${err.message})`
+                )
+              }
+              throw err
+            }
+          }
+          // 'dual' — handler intentionally handles the fallback.
+          return await originalHandler.call(this, request, reply)
+        }
+        // Fall through to SSE setup.
       }
 
-      // Set up SSE response
-      reply.raw.setHeader('Content-Type', 'text/event-stream')
-      reply.raw.setHeader('Cache-Control', 'no-cache')
-      reply.raw.setHeader('Connection', 'keep-alive')
-      reply.raw.setHeader('X-Accel-Buffering', 'no') // Disable Nginx buffering
-
-      // Create SSE context
+      // Set up SSE context. Headers are written lazily on the first send.
       const context = new SSEContext({
         reply,
         lastEventId: request.headers['last-event-id'],
@@ -502,19 +578,15 @@ async function fastifySSE (fastify, opts) {
       reply.sse = context
 
       let res
-      // Call original handler with SSE-enabled reply
-      // Note: Headers will be sent on first SSE send
       try {
         res = await originalHandler.call(this, request, reply)
       } catch (error) {
-        // If handler doesn't call keepAlive, close connection
         if (!context.shouldKeepAlive) {
           context.close()
         }
         throw error
       }
 
-      // If handler doesn't call keepAlive, close connection
       if (!context.shouldKeepAlive) {
         context.close()
       }
@@ -529,5 +601,5 @@ module.exports = fp(fastifySSE, {
   name: '@fastify/sse'
 })
 module.exports.default = fastifySSE
-module.exports.clientAcceptsSSE = clientAcceptsSSE
 module.exports.fastifySSE = fastifySSE
+module.exports.clientAcceptsSSE = clientAcceptsSSE

--- a/index.js
+++ b/index.js
@@ -392,10 +392,77 @@ class SSEContext {
   }
 }
 
+/**
+ * Determine whether the client's Accept header admits `text/event-stream`.
+ *
+ * Implements the RFC 9110 §12.5.1 precedence model for the media ranges that
+ * are relevant to SSE — `text/event-stream`, `text/*`, and `*\/*`. Other
+ * media-type parameters are ignored; only the `q` parameter is honored.
+ *
+ * Default (lenient) behavior returns true when:
+ *   - Accept is missing or empty (any media type is acceptable),
+ *   - `text/event-stream`, `text/*`, or `*\/*` appears with a quality > 0
+ *     and is the most specific match present in the header.
+ *
+ * Pass `{ strict: true }` to require an explicit `text/event-stream` token
+ * with quality > 0; ambiguous headers (`*\/*`, `text/*`, missing) return
+ * false in strict mode.
+ *
+ * The most specific matching range wins (exact > subtype wildcard > full
+ * wildcard), so `*\/*, text/event-stream;q=0` correctly returns false.
+ *
+ * Quality values outside [0, 1] are ignored and the entry's quality defaults
+ * to 1 (the spec default when no qvalue is present).
+ *
+ * @param {string|undefined} acceptHeader
+ * @param {{ strict?: boolean }} [options]
+ * @returns {boolean}
+ */
+function clientAcceptsSSE (acceptHeader, options) {
+  const strict = options?.strict === true
+  if (!acceptHeader) return !strict
+
+  let bestSpecificity = -1
+  let bestQuality = 0
+
+  for (const part of acceptHeader.split(',')) {
+    const [rawType, ...params] = part.split(';')
+    const type = rawType.trim().toLowerCase()
+
+    let specificity
+    if (type === 'text/event-stream') specificity = 3
+    else if (!strict && type === 'text/*') specificity = 2
+    else if (!strict && type === '*/*') specificity = 1
+    else continue
+
+    let quality = 1
+    for (const p of params) {
+      const eq = p.indexOf('=')
+      if (eq === -1) continue
+      const key = p.slice(0, eq).trim().toLowerCase()
+      if (key !== 'q') continue
+      const parsed = Number.parseFloat(p.slice(eq + 1).trim())
+      // Per RFC 9110, qvalue is in [0, 1]; anything else is invalid and
+      // ignored (the entry's quality stays at the default of 1).
+      if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) {
+        quality = parsed
+      }
+    }
+
+    if (specificity > bestSpecificity) {
+      bestSpecificity = specificity
+      bestQuality = quality
+    }
+  }
+
+  return bestSpecificity >= 0 && bestQuality > 0
+}
+
 async function fastifySSE (fastify, opts) {
   const {
     heartbeatInterval = 30000,
-    serializer = JSON.stringify
+    serializer = JSON.stringify,
+    strictAccept: pluginStrictAccept = false
   } = opts
 
   // Add route-level SSE handler
@@ -404,12 +471,16 @@ async function fastifySSE (fastify, opts) {
 
     const originalHandler = routeOptions.handler
     const sseOptions = typeof routeOptions.sse === 'object' ? routeOptions.sse : {}
+    const strictAccept = sseOptions.strictAccept ?? pluginStrictAccept
 
     routeOptions.handler = async function sseHandler (request, reply) {
-      // Check if client accepts SSE
-      const acceptHeader = request.headers.accept || ''
-      if (!acceptHeader.includes('text/event-stream')) {
-        // Fall back to regular handler for non-SSE requests
+      // Decide whether to handle this request as SSE.
+      //   - Default (strictAccept: false): spec-compliant per RFC 9110 —
+      //     admit SSE for `text/event-stream`, `text/*`, `*\/*`, and missing
+      //     Accept.
+      //   - strictAccept: true — require an explicit `text/event-stream`
+      //     token; ambiguous headers (`*\/*`, `text/*`, missing) fall through.
+      if (!clientAcceptsSSE(request.headers.accept, { strict: strictAccept })) {
         return await originalHandler.call(this, request, reply)
       }
 
@@ -458,4 +529,5 @@ module.exports = fp(fastifySSE, {
   name: '@fastify/sse'
 })
 module.exports.default = fastifySSE
+module.exports.clientAcceptsSSE = clientAcceptsSSE
 module.exports.fastifySSE = fastifySSE

--- a/index.js
+++ b/index.js
@@ -602,4 +602,3 @@ module.exports = fp(fastifySSE, {
 })
 module.exports.default = fastifySSE
 module.exports.fastifySSE = fastifySSE
-module.exports.clientAcceptsSSE = clientAcceptsSSE

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "fastify": "^5.x"
   },
   "dependencies": {
+    "@fastify/error": "^4.2.0",
     "fastify-plugin": "^5.0.0"
   },
   "devDependencies": {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -347,81 +347,6 @@ test('clientAcceptsSSE: out-of-range q-values are ignored (default q=1)', () => 
   assert.strictEqual(clientAcceptsSSE('*/*;q=2'), true)
 })
 
-test('SSE is served when client sends Accept: */*', async (t) => {
-  const fastify = Fastify({ logger: false })
-
-  t.after(async () => {
-    await fastify.close()
-  })
-
-  await fastify.register(fastifySSE)
-
-  fastify.get('/events', { sse: true }, async (request, reply) => {
-    await reply.sse.send({ data: 'hello' })
-  })
-
-  const response = await fastify.inject({
-    method: 'GET',
-    url: '/events',
-    headers: {
-      accept: '*/*'
-    }
-  })
-
-  assert.strictEqual(response.statusCode, 200)
-  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
-  assert.ok(response.body.includes('data: "hello"'))
-})
-
-test('SSE is served when client omits the Accept header', async (t) => {
-  const fastify = Fastify({ logger: false })
-
-  t.after(async () => {
-    await fastify.close()
-  })
-
-  await fastify.register(fastifySSE)
-
-  fastify.get('/events', { sse: true }, async (request, reply) => {
-    await reply.sse.send({ data: 'hello' })
-  })
-
-  const response = await fastify.inject({
-    method: 'GET',
-    url: '/events'
-    // no Accept header
-  })
-
-  assert.strictEqual(response.statusCode, 200)
-  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
-  assert.ok(response.body.includes('data: "hello"'))
-})
-
-test('SSE is served when client sends Accept: text/*', async (t) => {
-  const fastify = Fastify({ logger: false })
-
-  t.after(async () => {
-    await fastify.close()
-  })
-
-  await fastify.register(fastifySSE)
-
-  fastify.get('/events', { sse: true }, async (request, reply) => {
-    await reply.sse.send({ data: 'hello' })
-  })
-
-  const response = await fastify.inject({
-    method: 'GET',
-    url: '/events',
-    headers: {
-      accept: 'text/*'
-    }
-  })
-
-  assert.strictEqual(response.statusCode, 200)
-  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
-})
-
 test('clientAcceptsSSE: strict mode only admits explicit text/event-stream', () => {
   const strict = { strict: true }
   assert.strictEqual(clientAcceptsSSE(undefined, strict), false)
@@ -435,16 +360,136 @@ test('clientAcceptsSSE: strict mode only admits explicit text/event-stream', () 
   assert.strictEqual(clientAcceptsSSE('text/event-stream;q=0.5', strict), true)
 })
 
-test('plugin-level strictAccept opts out of the SSE-wins default', async (t) => {
-  const fastify = Fastify({ logger: false })
+// -----------------------------------------------------------------------
+// sse: 'only' (SSE-only routes)
+// -----------------------------------------------------------------------
 
-  t.after(async () => {
-    await fastify.close()
+test("sse: 'only' admits SSE for */*", async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
   })
 
-  await fastify.register(fastifySSE, { strictAccept: true })
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: '*/*' }
+  })
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+  assert.ok(response.body.includes('data: "hello"'))
+})
 
-  fastify.get('/data', { sse: true }, async (request, reply) => {
+test("sse: 'only' admits SSE for missing Accept", async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/events' })
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+  assert.ok(response.body.includes('data: "hello"'))
+})
+
+test("sse: 'only' admits SSE for text/*", async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: 'text/*' }
+  })
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+})
+
+test("sse: 'only' returns 406 when client explicitly refuses SSE", async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: 'application/json' }
+  })
+  assert.strictEqual(response.statusCode, 406)
+  assert.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
+  const body = JSON.parse(response.body)
+  assert.strictEqual(body.statusCode, 406)
+  assert.strictEqual(body.error, 'Not Acceptable')
+  assert.match(body.message, /text\/event-stream/)
+})
+
+test("sse: 'only' returns 406 when client sends text/event-stream;q=0", async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: '*/*, text/event-stream;q=0' }
+  })
+  assert.strictEqual(response.statusCode, 406)
+})
+
+test("sse: { kind: 'only', heartbeat: false } object form is supported", async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', {
+    sse: { kind: 'only', heartbeat: false }
+  }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const wildcard = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: '*/*' }
+  })
+  assert.strictEqual(wildcard.headers['content-type'], 'text/event-stream')
+
+  const refused = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: 'application/json' }
+  })
+  assert.strictEqual(refused.statusCode, 406)
+})
+
+// -----------------------------------------------------------------------
+// sse: 'dual' (explicit dual-mode routes)
+// -----------------------------------------------------------------------
+
+test("sse: 'dual' routes only explicit text/event-stream to SSE", async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  fastify.get('/data', { sse: 'dual' }, async (request, reply) => {
     if (reply.sse) {
       await reply.sse.send({ data: 'streamed' })
     } else {
@@ -452,7 +497,7 @@ test('plugin-level strictAccept opts out of the SSE-wins default', async (t) => 
     }
   })
 
-  // */* now falls back because strictAccept refuses ambiguous headers
+  // */* → falls through to JSON
   const wildcard = await fastify.inject({
     method: 'GET',
     url: '/data',
@@ -461,7 +506,19 @@ test('plugin-level strictAccept opts out of the SSE-wins default', async (t) => 
   assert.strictEqual(wildcard.headers['content-type'], 'application/json; charset=utf-8')
   assert.deepStrictEqual(JSON.parse(wildcard.body), { message: 'json' })
 
-  // Explicit text/event-stream still gets SSE
+  // missing → JSON
+  const missing = await fastify.inject({ method: 'GET', url: '/data' })
+  assert.deepStrictEqual(JSON.parse(missing.body), { message: 'json' })
+
+  // application/json → JSON
+  const jsonResponse = await fastify.inject({
+    method: 'GET',
+    url: '/data',
+    headers: { accept: 'application/json' }
+  })
+  assert.deepStrictEqual(JSON.parse(jsonResponse.body), { message: 'json' })
+
+  // text/event-stream → SSE
   const explicit = await fastify.inject({
     method: 'GET',
     url: '/data',
@@ -471,80 +528,98 @@ test('plugin-level strictAccept opts out of the SSE-wins default', async (t) => 
   assert.ok(explicit.body.includes('data: "streamed"'))
 })
 
-test('route-level strictAccept overrides plugin-level setting', async (t) => {
+// -----------------------------------------------------------------------
+// sse: true (legacy back-compat + clearer error on misuse)
+// -----------------------------------------------------------------------
+
+test("sse: true behaves like 'dual' for routing (back-compat)", async (t) => {
   const fastify = Fastify({ logger: false })
-
-  t.after(async () => {
-    await fastify.close()
-  })
-
-  // Plugin default: lenient
-  await fastify.register(fastifySSE)
-
-  // Per-route override: strict
-  fastify.get('/strict', {
-    sse: { strictAccept: true }
-  }, async (request, reply) => {
-    if (reply.sse) {
-      await reply.sse.send({ data: 'streamed' })
-    } else {
-      return { message: 'json' }
-    }
-  })
-
-  // Default route uses plugin default (admits SSE for */*)
-  fastify.get('/default', { sse: true }, async (request, reply) => {
-    await reply.sse.send({ data: 'streamed' })
-  })
-
-  const strictWildcard = await fastify.inject({
-    method: 'GET',
-    url: '/strict',
-    headers: { accept: '*/*' }
-  })
-  assert.strictEqual(strictWildcard.headers['content-type'], 'application/json; charset=utf-8')
-
-  const defaultWildcard = await fastify.inject({
-    method: 'GET',
-    url: '/default',
-    headers: { accept: '*/*' }
-  })
-  assert.strictEqual(defaultWildcard.headers['content-type'], 'text/event-stream')
-})
-
-test('handler can gate fallback on reply.sse presence', async (t) => {
-  const fastify = Fastify({ logger: false })
-
-  t.after(async () => {
-    await fastify.close()
-  })
-
+  t.after(async () => { await fastify.close() })
   await fastify.register(fastifySSE)
 
   fastify.get('/data', { sse: true }, async (request, reply) => {
-    if (reply.sse) {
+    const acceptHeader = request.headers.accept || ''
+    if (acceptHeader.includes('text/event-stream')) {
       await reply.sse.send({ data: 'streamed' })
     } else {
       return { message: 'json' }
     }
   })
 
-  // */* → plugin admits SSE → handler sees reply.sse and streams
-  const sseResponse = await fastify.inject({
+  // */* → falls through (strict gate); handler returns JSON
+  const wildcard = await fastify.inject({
     method: 'GET',
     url: '/data',
     headers: { accept: '*/*' }
   })
-  assert.strictEqual(sseResponse.headers['content-type'], 'text/event-stream')
-  assert.ok(sseResponse.body.includes('data: "streamed"'))
+  assert.deepStrictEqual(JSON.parse(wildcard.body), { message: 'json' })
 
-  // application/json → plugin falls back → handler returns JSON
-  const jsonResponse = await fastify.inject({
+  // text/event-stream → SSE
+  const explicit = await fastify.inject({
     method: 'GET',
     url: '/data',
-    headers: { accept: 'application/json' }
+    headers: { accept: 'text/event-stream' }
   })
-  assert.strictEqual(jsonResponse.statusCode, 200)
-  assert.strictEqual(jsonResponse.headers['content-type'], 'application/json; charset=utf-8')
-  assert.deepStrictEqual(JSON.parse(jsonResponse.body), { message: 'json' })
+  assert.strictEqual(explicit.headers['content-type'], 'text/event-stream')
+})
+
+test('sse: true with SSE-only handler gives a clearer error on misuse', async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  // Handler is SSE-only — calls reply.sse.send unconditionally — but
+  // registered with the legacy `sse: true` flag. When a wildcard Accept
+  // arrives, the strict gate falls through, reply.sse is undefined, and the
+  // handler trips the TypeError. The plugin should rethrow with guidance to
+  // switch to `sse: 'only'`.
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: '*/*' }
+  })
+
+  // The rethrown error reaches Fastify's default error handler.
+  assert.strictEqual(response.statusCode, 500)
+  assert.match(response.body, /sse: 'only'/)
+})
+
+test('sse: true with object form (no kind) is treated as legacy', async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  // No `kind` field — back-compat with existing `{ heartbeat, serializer }` users.
+  fastify.get('/events', {
+    sse: { heartbeat: false }
+  }, async (request, reply) => {
+    const acceptHeader = request.headers.accept || ''
+    if (acceptHeader.includes('text/event-stream')) {
+      await reply.sse.send({ data: 'streamed' })
+    } else {
+      return { message: 'json' }
+    }
+  })
+
+  const wildcard = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: '*/*' }
+  })
+  assert.deepStrictEqual(JSON.parse(wildcard.body), { message: 'json' })
+})
+
+test('unknown sse kind throws at registration', async (t) => {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => { await fastify.close() })
+  await fastify.register(fastifySSE)
+
+  assert.throws(
+    () => fastify.get('/events', { sse: { kind: 'maybe' } }, async () => {}),
+    /unknown sse kind 'maybe'/
+  )
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -5,6 +5,7 @@ const { strict: assert } = require('node:assert')
 const Fastify = require('fastify')
 const { Readable } = require('stream')
 const fastifySSE = require('../index.js')
+const { clientAcceptsSSE } = require('../index.js')
 
 test('basic SSE functionality', async (t) => {
   const fastify = Fastify({ logger: false })
@@ -292,4 +293,258 @@ test('reply.sse.stream() for pipeline operations', async (t) => {
   assert.ok(body.includes('data: "second"'))
   assert.ok(body.includes('id: 3'))
   assert.ok(body.includes('data: "third"'))
+})
+
+test('clientAcceptsSSE: missing Accept admits SSE', () => {
+  assert.strictEqual(clientAcceptsSSE(undefined), true)
+  assert.strictEqual(clientAcceptsSSE(''), true)
+})
+
+test('clientAcceptsSSE: */* admits SSE', () => {
+  assert.strictEqual(clientAcceptsSSE('*/*'), true)
+  assert.strictEqual(clientAcceptsSSE('application/json, */*'), true)
+})
+
+test('clientAcceptsSSE: text/* admits SSE', () => {
+  assert.strictEqual(clientAcceptsSSE('text/*'), true)
+})
+
+test('clientAcceptsSSE: explicit text/event-stream admits SSE', () => {
+  assert.strictEqual(clientAcceptsSSE('text/event-stream'), true)
+  assert.strictEqual(clientAcceptsSSE('text/event-stream;charset=utf-8'), true)
+})
+
+test('clientAcceptsSSE: explicit non-matching types do not admit SSE', () => {
+  assert.strictEqual(clientAcceptsSSE('application/json'), false)
+  assert.strictEqual(clientAcceptsSSE('text/html, text/plain'), false)
+})
+
+test('clientAcceptsSSE: q=0 on most specific match overrides wildcards', () => {
+  // RFC 9110: the most specific match wins. text/event-stream;q=0 explicitly
+  // rejects SSE even though */* would otherwise admit it.
+  assert.strictEqual(clientAcceptsSSE('*/*, text/event-stream;q=0'), false)
+  assert.strictEqual(clientAcceptsSSE('text/*, text/event-stream;q=0'), false)
+})
+
+test('clientAcceptsSSE: q=0 on wildcard does not block explicit match', () => {
+  assert.strictEqual(clientAcceptsSSE('*/*;q=0, text/event-stream'), true)
+})
+
+test('clientAcceptsSSE: q-values are parsed but do not affect admission past 0', () => {
+  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=0.1'), true)
+  assert.strictEqual(clientAcceptsSSE('application/json;q=0.9, */*;q=0.1'), true)
+})
+
+test('clientAcceptsSSE: out-of-range q-values are ignored (default q=1)', () => {
+  // q=2 / q=-1 / q=abc are invalid per RFC 9110; entry falls back to q=1
+  // and still admits SSE.
+  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=2'), true)
+  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=-1'), true)
+  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=abc'), true)
+  // Invalid q on the most specific match doesn't unblock SSE if a valid
+  // qvalue elsewhere makes the entry inadmissible. Here q=2 is invalid →
+  // defaults to 1 → still admits.
+  assert.strictEqual(clientAcceptsSSE('*/*;q=2'), true)
+})
+
+test('SSE is served when client sends Accept: */*', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: '*/*'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+  assert.ok(response.body.includes('data: "hello"'))
+})
+
+test('SSE is served when client omits the Accept header', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events'
+    // no Accept header
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+  assert.ok(response.body.includes('data: "hello"'))
+})
+
+test('SSE is served when client sends Accept: text/*', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: true }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: {
+      accept: 'text/*'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+})
+
+test('clientAcceptsSSE: strict mode only admits explicit text/event-stream', () => {
+  const strict = { strict: true }
+  assert.strictEqual(clientAcceptsSSE(undefined, strict), false)
+  assert.strictEqual(clientAcceptsSSE('', strict), false)
+  assert.strictEqual(clientAcceptsSSE('*/*', strict), false)
+  assert.strictEqual(clientAcceptsSSE('text/*', strict), false)
+  assert.strictEqual(clientAcceptsSSE('application/json', strict), false)
+  assert.strictEqual(clientAcceptsSSE('text/event-stream', strict), true)
+  assert.strictEqual(clientAcceptsSSE('application/json, text/event-stream', strict), true)
+  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=0', strict), false)
+  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=0.5', strict), true)
+})
+
+test('plugin-level strictAccept opts out of the SSE-wins default', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE, { strictAccept: true })
+
+  fastify.get('/data', { sse: true }, async (request, reply) => {
+    if (reply.sse) {
+      await reply.sse.send({ data: 'streamed' })
+    } else {
+      return { message: 'json' }
+    }
+  })
+
+  // */* now falls back because strictAccept refuses ambiguous headers
+  const wildcard = await fastify.inject({
+    method: 'GET',
+    url: '/data',
+    headers: { accept: '*/*' }
+  })
+  assert.strictEqual(wildcard.headers['content-type'], 'application/json; charset=utf-8')
+  assert.deepStrictEqual(JSON.parse(wildcard.body), { message: 'json' })
+
+  // Explicit text/event-stream still gets SSE
+  const explicit = await fastify.inject({
+    method: 'GET',
+    url: '/data',
+    headers: { accept: 'text/event-stream' }
+  })
+  assert.strictEqual(explicit.headers['content-type'], 'text/event-stream')
+  assert.ok(explicit.body.includes('data: "streamed"'))
+})
+
+test('route-level strictAccept overrides plugin-level setting', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  // Plugin default: lenient
+  await fastify.register(fastifySSE)
+
+  // Per-route override: strict
+  fastify.get('/strict', {
+    sse: { strictAccept: true }
+  }, async (request, reply) => {
+    if (reply.sse) {
+      await reply.sse.send({ data: 'streamed' })
+    } else {
+      return { message: 'json' }
+    }
+  })
+
+  // Default route uses plugin default (admits SSE for */*)
+  fastify.get('/default', { sse: true }, async (request, reply) => {
+    await reply.sse.send({ data: 'streamed' })
+  })
+
+  const strictWildcard = await fastify.inject({
+    method: 'GET',
+    url: '/strict',
+    headers: { accept: '*/*' }
+  })
+  assert.strictEqual(strictWildcard.headers['content-type'], 'application/json; charset=utf-8')
+
+  const defaultWildcard = await fastify.inject({
+    method: 'GET',
+    url: '/default',
+    headers: { accept: '*/*' }
+  })
+  assert.strictEqual(defaultWildcard.headers['content-type'], 'text/event-stream')
+})
+
+test('handler can gate fallback on reply.sse presence', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/data', { sse: true }, async (request, reply) => {
+    if (reply.sse) {
+      await reply.sse.send({ data: 'streamed' })
+    } else {
+      return { message: 'json' }
+    }
+  })
+
+  // */* → plugin admits SSE → handler sees reply.sse and streams
+  const sseResponse = await fastify.inject({
+    method: 'GET',
+    url: '/data',
+    headers: { accept: '*/*' }
+  })
+  assert.strictEqual(sseResponse.headers['content-type'], 'text/event-stream')
+  assert.ok(sseResponse.body.includes('data: "streamed"'))
+
+  // application/json → plugin falls back → handler returns JSON
+  const jsonResponse = await fastify.inject({
+    method: 'GET',
+    url: '/data',
+    headers: { accept: 'application/json' }
+  })
+  assert.strictEqual(jsonResponse.statusCode, 200)
+  assert.strictEqual(jsonResponse.headers['content-type'], 'application/json; charset=utf-8')
+  assert.deepStrictEqual(JSON.parse(jsonResponse.body), { message: 'json' })
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -5,7 +5,6 @@ const { strict: assert } = require('node:assert')
 const Fastify = require('fastify')
 const { Readable } = require('stream')
 const fastifySSE = require('../index.js')
-const { clientAcceptsSSE } = require('../index.js')
 
 test('basic SSE functionality', async (t) => {
   const fastify = Fastify({ logger: false })
@@ -293,71 +292,6 @@ test('reply.sse.stream() for pipeline operations', async (t) => {
   assert.ok(body.includes('data: "second"'))
   assert.ok(body.includes('id: 3'))
   assert.ok(body.includes('data: "third"'))
-})
-
-test('clientAcceptsSSE: missing Accept admits SSE', () => {
-  assert.strictEqual(clientAcceptsSSE(undefined), true)
-  assert.strictEqual(clientAcceptsSSE(''), true)
-})
-
-test('clientAcceptsSSE: */* admits SSE', () => {
-  assert.strictEqual(clientAcceptsSSE('*/*'), true)
-  assert.strictEqual(clientAcceptsSSE('application/json, */*'), true)
-})
-
-test('clientAcceptsSSE: text/* admits SSE', () => {
-  assert.strictEqual(clientAcceptsSSE('text/*'), true)
-})
-
-test('clientAcceptsSSE: explicit text/event-stream admits SSE', () => {
-  assert.strictEqual(clientAcceptsSSE('text/event-stream'), true)
-  assert.strictEqual(clientAcceptsSSE('text/event-stream;charset=utf-8'), true)
-})
-
-test('clientAcceptsSSE: explicit non-matching types do not admit SSE', () => {
-  assert.strictEqual(clientAcceptsSSE('application/json'), false)
-  assert.strictEqual(clientAcceptsSSE('text/html, text/plain'), false)
-})
-
-test('clientAcceptsSSE: q=0 on most specific match overrides wildcards', () => {
-  // RFC 9110: the most specific match wins. text/event-stream;q=0 explicitly
-  // rejects SSE even though */* would otherwise admit it.
-  assert.strictEqual(clientAcceptsSSE('*/*, text/event-stream;q=0'), false)
-  assert.strictEqual(clientAcceptsSSE('text/*, text/event-stream;q=0'), false)
-})
-
-test('clientAcceptsSSE: q=0 on wildcard does not block explicit match', () => {
-  assert.strictEqual(clientAcceptsSSE('*/*;q=0, text/event-stream'), true)
-})
-
-test('clientAcceptsSSE: q-values are parsed but do not affect admission past 0', () => {
-  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=0.1'), true)
-  assert.strictEqual(clientAcceptsSSE('application/json;q=0.9, */*;q=0.1'), true)
-})
-
-test('clientAcceptsSSE: out-of-range q-values are ignored (default q=1)', () => {
-  // q=2 / q=-1 / q=abc are invalid per RFC 9110; entry falls back to q=1
-  // and still admits SSE.
-  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=2'), true)
-  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=-1'), true)
-  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=abc'), true)
-  // Invalid q on the most specific match doesn't unblock SSE if a valid
-  // qvalue elsewhere makes the entry inadmissible. Here q=2 is invalid →
-  // defaults to 1 → still admits.
-  assert.strictEqual(clientAcceptsSSE('*/*;q=2'), true)
-})
-
-test('clientAcceptsSSE: strict mode only admits explicit text/event-stream', () => {
-  const strict = { strict: true }
-  assert.strictEqual(clientAcceptsSSE(undefined, strict), false)
-  assert.strictEqual(clientAcceptsSSE('', strict), false)
-  assert.strictEqual(clientAcceptsSSE('*/*', strict), false)
-  assert.strictEqual(clientAcceptsSSE('text/*', strict), false)
-  assert.strictEqual(clientAcceptsSSE('application/json', strict), false)
-  assert.strictEqual(clientAcceptsSSE('text/event-stream', strict), true)
-  assert.strictEqual(clientAcceptsSSE('application/json, text/event-stream', strict), true)
-  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=0', strict), false)
-  assert.strictEqual(clientAcceptsSSE('text/event-stream;q=0.5', strict), true)
 })
 
 // -----------------------------------------------------------------------

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -463,7 +463,7 @@ test("sse: 'dual' routes only explicit text/event-stream to SSE", async (t) => {
 })
 
 // -----------------------------------------------------------------------
-// sse: true (legacy back-compat + clearer error on misuse)
+// sse: true (legacy back-compat + explanatory error on misuse)
 // -----------------------------------------------------------------------
 
 test("sse: true behaves like 'dual' for routing (back-compat)", async (t) => {
@@ -497,7 +497,7 @@ test("sse: true behaves like 'dual' for routing (back-compat)", async (t) => {
   assert.strictEqual(explicit.headers['content-type'], 'text/event-stream')
 })
 
-test('sse: true with SSE-only handler gives a clearer error on misuse', async (t) => {
+test('sse: true with SSE-only handler emits an explanatory error on misuse', async (t) => {
   const fastify = Fastify({ logger: false })
   t.after(async () => { await fastify.close() })
   await fastify.register(fastifySSE)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,17 +7,36 @@ declare module 'fastify' {
   }
 
   interface RouteShorthandOptions {
-    sse?: boolean | {
-      heartbeat?: boolean
-      serializer?: (data: any) => string
-      /**
-       * Require an explicit `text/event-stream` token in the Accept header
-       * for this route. Overrides the plugin-level `strictAccept` setting.
-       * @default false
-       */
-      strictAccept?: boolean
-    }
+    sse?: SSERouteOptions
   }
+}
+
+/**
+ * Declares how a route handles the SSE/non-SSE split.
+ *
+ * - `'only'` — SSE-only. Lenient gate: any spec-compliant Accept admits
+ *   SSE. Clients that explicitly refuse SSE receive 406 Not Acceptable.
+ * - `'dual'` — Route serves both SSE and non-SSE on the same handler.
+ *   Strict gate: only an explicit `text/event-stream` token admits SSE;
+ *   the handler must branch on `reply.sse` to serve other clients.
+ */
+export type SSERouteKind = 'only' | 'dual'
+
+/**
+ * Per-route SSE options.
+ *
+ * Accepted values:
+ * - `true` — Back-compat. Routes like `'dual'` for gate behavior; on the
+ *   fallback path the plugin rethrows with a clearer error if the handler
+ *   tries to use `reply.sse` (signals "use `'only'` instead").
+ * - `'only'` / `'dual'` — Shorthand for the matching kind.
+ * - Object form — Same kinds via `kind`, plus per-route option overrides.
+ *   `kind` omitted = back-compat behavior, equivalent to `sse: true`.
+ */
+export type SSERouteOptions = boolean | SSERouteKind | {
+  kind?: SSERouteKind
+  heartbeat?: boolean
+  serializer?: (data: any) => string
 }
 
 export interface SSEPluginOptions {
@@ -33,15 +52,6 @@ export interface SSEPluginOptions {
    * @default JSON.stringify
    */
   serializer?: (data: any) => string
-
-  /**
-   * Require an explicit `text/event-stream` token in the Accept header to
-   * serve SSE. When false (default), the plugin follows RFC 9110 §12.5.1 and
-   * admits SSE for `*\/*`, `text/*`, and missing Accept headers. When true,
-   * those ambiguous headers fall through to the regular handler.
-   * @default false
-   */
-  strictAccept?: boolean
 }
 
 export interface SSEMessage {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,8 +27,8 @@ export type SSERouteKind = 'only' | 'dual'
  *
  * Accepted values:
  * - `true` — Back-compat. Routes like `'dual'` for gate behavior; on the
- *   fallback path the plugin rethrows with a clearer error if the handler
- *   tries to use `reply.sse` (signals "use `'only'` instead").
+ *   fallback path the plugin rethrows with a message naming `'only'` as
+ *   the fix if the handler tries to use `reply.sse`.
  * - `'only'` / `'dual'` — Shorthand for the matching kind.
  * - Object form — Same kinds via `kind`, plus per-route option overrides.
  *   `kind` omitted = back-compat behavior, equivalent to `sse: true`.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -141,22 +141,4 @@ export interface SSEReplyInterface {
 
 export declare const fastifySSE: FastifyPluginAsync<SSEPluginOptions>
 
-/**
- * Determine whether the client's Accept header admits `text/event-stream`,
- * implementing the RFC 9110 §12.5.1 precedence model for the media ranges
- * relevant to SSE (`text/event-stream`, `text/*`, `*\/*`).
- *
- * Default (lenient) returns true when the header is missing, empty, or
- * admits SSE via a matching range with quality > 0. The most specific
- * matching range wins, so `*\/*, text/event-stream;q=0` returns false.
- *
- * Pass `{ strict: true }` to require an explicit `text/event-stream` token
- * with quality > 0; ambiguous headers (`*\/*`, `text/*`, missing) return
- * false in strict mode.
- */
-export declare function clientAcceptsSSE (
-  acceptHeader: string | undefined,
-  options?: { strict?: boolean }
-): boolean
-
 export default fastifySSE

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,12 @@ declare module 'fastify' {
     sse?: boolean | {
       heartbeat?: boolean
       serializer?: (data: any) => string
+      /**
+       * Require an explicit `text/event-stream` token in the Accept header
+       * for this route. Overrides the plugin-level `strictAccept` setting.
+       * @default false
+       */
+      strictAccept?: boolean
     }
   }
 }
@@ -27,6 +33,15 @@ export interface SSEPluginOptions {
    * @default JSON.stringify
    */
   serializer?: (data: any) => string
+
+  /**
+   * Require an explicit `text/event-stream` token in the Accept header to
+   * serve SSE. When false (default), the plugin follows RFC 9110 §12.5.1 and
+   * admits SSE for `*\/*`, `text/*`, and missing Accept headers. When true,
+   * those ambiguous headers fall through to the regular handler.
+   * @default false
+   */
+  strictAccept?: boolean
 }
 
 export interface SSEMessage {
@@ -115,5 +130,23 @@ export interface SSEReplyInterface {
 }
 
 export declare const fastifySSE: FastifyPluginAsync<SSEPluginOptions>
+
+/**
+ * Determine whether the client's Accept header admits `text/event-stream`,
+ * implementing the RFC 9110 §12.5.1 precedence model for the media ranges
+ * relevant to SSE (`text/event-stream`, `text/*`, `*\/*`).
+ *
+ * Default (lenient) returns true when the header is missing, empty, or
+ * admits SSE via a matching range with quality > 0. The most specific
+ * matching range wins, so `*\/*, text/event-stream;q=0` returns false.
+ *
+ * Pass `{ strict: true }` to require an explicit `text/event-stream` token
+ * with quality > 0; ambiguous headers (`*\/*`, `text/*`, missing) return
+ * false in strict mode.
+ */
+export declare function clientAcceptsSSE (
+  acceptHeader: string | undefined,
+  options?: { strict?: boolean }
+): boolean
 
 export default fastifySSE

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -196,7 +196,7 @@ expect(routeOptions3).type.toBeAssignableTo<RouteShorthandOptions>()
 
 // Test invalid route options - these tests verify type checking
 app.get('/invalid', {
-  // @ts-expect-error Type 'string' is not assignable
+  // @ts-expect-error Type '"invalid"' is not assignable to type 'SSERouteOptions'
   sse: 'invalid'
 }, async (request, reply) => { })
 app.get('/invalid2', {
@@ -205,3 +205,19 @@ app.get('/invalid2', {
     unknownOption: true
   }
 }, async (request, reply) => { })
+
+// Test valid kind shorthand
+app.get('/only', { sse: 'only' }, async (request, reply) => {
+  return reply.sse.send({ data: 'hello' })
+})
+app.get('/dual', { sse: 'dual' }, async (request, reply) => {
+  if (reply.sse) return reply.sse.send({ data: 'hello' })
+  return { fallback: true }
+})
+
+// Test object form with kind
+app.get('/only-obj', {
+  sse: { kind: 'only', heartbeat: false }
+}, async (request, reply) => {
+  return reply.sse.send({ data: 'hello' })
+})


### PR DESCRIPTION
Per RFC 9110 §12.5.1 (https://www.rfc-editor.org/rfc/rfc9110#name-accept), a wildcard Accept header (*/*, text/*) or a missing Accept header means any media type is acceptable, including `text/event-stream`. The server gets to choose. `@fastify/sse` currently treats those headers as "not SSE" and falls through to the route's regular handler. For SSE-only routes the regular handler is the same handler that uses reply.sse, and reply.sse is undefined on the fallback path, so the request 500s with a cryptic `TypeError: Cannot read properties of undefined (reading 'send')`.

That hits anything that doesn't send an explicit `text/event-stream` header: Postman defaults, curl defaults, fetch() defaults, plain navigations.

After this PR, routes can now declare their intent up front:

* sse: **'only'** - SSE-only route. Lenient gate per RFC: any spec-compliant Accept (`text/event-stream`, `text/*`, `*/*`, missing) admits SSE. Clients that explicitly refuse SSE (Accept: `application/json`, or `text/event-stream;q=0`) get 406 Not Acceptable.
* sse: **'dual'** - Same handler serves both SSE and non-SSE clients. Strict gate: only an explicit `text/event-stream` token routes to SSE; everything else (including */*) reaches the handler with reply.sse undefined, so the handler can serve a non-SSE response. This preserves the convention that wildcards prefer the richer non-SSE representation when the route offers a choice.
* sse: **true** - Unchanged routing (back-compat). On the fallback path the plugin now rethrows with a clearer error if the handler trips on undefined reply.sse, naming sse: 'only' as the fix.

`sse: true` routes behave exactly as before - the existing fallback pattern, the existing tests, and the documented examples all keep   working. New routes can opt into the explicit kinds without affecting old ones.

Safe for a minor bump pre-1.0: no behavioral change for any existing `sse: true` registration; only additive surface ('only', 'dual', the object form's kind field).

#### Checklist

- [X] run `npm run test && npm run benchmark --if-present`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
