### PR TITLE
chore: bump version to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/sse",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Server-Sent Events plugin for Fastify",
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
This PR bumps the version to v0.5.0.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
