### PR TITLE
feat: allow custom response status code for SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,29 @@ fastify.get('/events', { sse: true }, async (request, reply) => {
 - `reply.sse.close()`: Manually close the connection
 - `reply.sse.replay(callback)`: Handle message replay using Last-Event-ID
 - `reply.sse.onClose(callback)`: Register callback for when connection closes
-- `reply.sse.sendHeaders()`: Manually send headers (called automatically on first write)
+- `reply.sse.sendHeaders(statusCode?)`: Manually send headers (called automatically on first write)
+
+### Custom Response Status Code
+
+The SSE response defaults to `200 OK`. To use a different status, either call
+`reply.code()` before the first SSE write, or pass the status directly to a
+manual `reply.sse.sendHeaders()` call:
+
+```javascript
+fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+  reply.code(201)
+  await reply.sse.send({ data: 'created' })
+})
+
+fastify.get('/events-explicit', { sse: 'only' }, async (request, reply) => {
+  reply.sse.sendHeaders(201)
+  await reply.sse.send({ data: 'created' })
+})
+```
+
+An explicit `sendHeaders()` argument takes precedence over `reply.code()`.
+Once the first SSE write commits the response headers, later `reply.code()`
+or `sendHeaders()` calls have no effect.
 
 ## Advanced Usage
 

--- a/index.js
+++ b/index.js
@@ -416,14 +416,19 @@ class SSEContext {
   /**
    * Sends HTTP headers for the SSE response if not already sent.
    * Applies the SSE-specific response headers, transfers any headers set
-   * via reply.header(), and calls writeHead(200). Called automatically
-   * before the first SSE data is sent, but can also be called manually.
+   * via reply.header(), and writes the response head. The status code is
+   * resolved in order: the explicit `statusCode` argument, then the value
+   * set via reply.code(), then 200. The automatic call before the first
+   * SSE write passes no argument, so an explicit status only takes effect
+   * on manual calls made before any data is sent.
    *
    * Until this fires, the response is not yet committed as SSE — a handler
    * that never writes SSE data will return through Fastify's normal
    * serialization path.
+   *
+   * @param {number} [statusCode] - HTTP status for the SSE response.
    */
-  sendHeaders () {
+  sendHeaders (statusCode) {
     if (!this.#headersSent) {
       this.reply.raw.setHeader('Content-Type', 'text/event-stream')
       this.reply.raw.setHeader('Cache-Control', 'no-cache')
@@ -436,7 +441,10 @@ class SSEContext {
         this.reply.raw.setHeader(name, value)
       }
 
-      this.reply.raw.writeHead(200)
+      // Status precedence: explicit sendHeaders() argument, then the value
+      // the handler set via reply.code() (stored on raw.statusCode), then
+      // 200 as the final fallback.
+      this.reply.raw.writeHead(statusCode ?? this.reply.raw.statusCode ?? 200)
       this.#headersSent = true
 
       // Start the heartbeat only once the response is committed as SSE.

--- a/test/status-code.test.js
+++ b/test/status-code.test.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const { test } = require('node:test')
+const { strict: assert } = require('node:assert')
+const Fastify = require('fastify')
+const fastifySSE = require('../index.js')
+
+test('SSE response should default to status 200', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    await reply.sse.send({ data: 'hello' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: 'text/event-stream' }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+  assert.ok(response.body.includes('data: "hello"'))
+})
+
+test('reply.code() before first SSE write should set the response status', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    reply.code(201)
+    await reply.sse.send({ data: 'created' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: 'text/event-stream' }
+  })
+
+  assert.strictEqual(response.statusCode, 201)
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+  assert.ok(response.body.includes('data: "created"'))
+})
+
+test('reply.sse.sendHeaders(statusCode) should set the response status', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    reply.sse.sendHeaders(202)
+    await reply.sse.send({ data: 'accepted' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: 'text/event-stream' }
+  })
+
+  assert.strictEqual(response.statusCode, 202)
+  assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+  assert.ok(response.body.includes('data: "accepted"'))
+})
+
+test('explicit sendHeaders(statusCode) should take precedence over reply.code()', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    reply.code(201)
+    reply.sse.sendHeaders(202)
+    await reply.sse.send({ data: 'accepted' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: 'text/event-stream' }
+  })
+
+  assert.strictEqual(response.statusCode, 202)
+})
+
+test('status changes after headers are committed should have no effect', async (t) => {
+  const fastify = Fastify({ logger: false })
+
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  await fastify.register(fastifySSE)
+
+  fastify.get('/events', { sse: 'only' }, async (request, reply) => {
+    await reply.sse.send({ data: 'first' })
+    reply.sse.sendHeaders(500)
+    await reply.sse.send({ data: 'second' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/events',
+    headers: { accept: 'text/event-stream' }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.ok(response.body.includes('data: "first"'))
+  assert.ok(response.body.includes('data: "second"'))
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -138,11 +138,14 @@ export interface SSEReplyInterface {
   /**
    * Send HTTP headers for the SSE response if not already sent.
    * This method ensures headers set via reply.header() are transferred
-   * to the raw response before calling writeHead(200).
-   * Called automatically before the first SSE data is sent, but can
-   * also be called manually if needed.
+   * to the raw response before writing the response head. The status code
+   * is resolved in order: the explicit `statusCode` argument, then the
+   * value set via reply.code(), then 200.
+   * Called automatically (without arguments) before the first SSE data is
+   * sent, but can also be called manually — call it before any data is
+   * written for an explicit status to take effect.
    */
-  sendHeaders(): void
+  sendHeaders(statusCode?: number): void
 }
 
 export declare const fastifySSE: FastifyPluginAsync<SSEPluginOptions>


### PR DESCRIPTION
## Summary

The SSE response head was hardcoded to `writeHead(200)`. This PR makes the status code configurable, resolved in order of precedence:

1. Explicit argument: `reply.sse.sendHeaders(statusCode)`
2. Value set via `reply.code()` before the first SSE write
3. `200` as the fallback

```javascript
fastify.get('/events', { sse: 'only' }, async (request, reply) => {
  reply.code(201)
  await reply.sse.send({ data: 'created' })
})

fastify.get('/events-explicit', { sse: 'only' }, async (request, reply) => {
  reply.sse.sendHeaders(201)
  await reply.sse.send({ data: 'created' })
})
```

Notes:

- The automatic `sendHeaders()` call on first write passes no argument, so an explicit status only takes effect on manual calls made before any data is sent; `reply.code()` covers the lazy-commit path.
- Once the first SSE write commits the headers, later `reply.code()` / `sendHeaders()` calls have no effect (unchanged behavior).
- Status validation is left to Node's `writeHead`, which throws on out-of-range codes.

## Changes

- `index.js` — `sendHeaders(statusCode)` optional parameter; resolve status as described above instead of hardcoding 200
- `types/index.d.ts` — updated `sendHeaders(statusCode?: number): void` signature and JSDoc
- `README.md` — new "Custom Response Status Code" section
- `test/status-code.test.js` — tests for the default, `reply.code()`, explicit argument, precedence, and no-effect-after-commit

## Checklist

- [x] run `npm run test` and `npm run lint` (this repo has no benchmark script)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines