### PR TITLE
chore: return to typescript v6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,7 @@ updates:
       - dependency-name: "eslint"
       - dependency-name: "neostandard"
       - dependency-name: "@stylistic/*"
+      - dependency-name: "typescript"
     open-pull-requests-limit: 10
     groups:
       # Production dependencies with breaking changes

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.0.0",
     "neostandard": "^0.13.0",
     "tstyche": "^7.1.0",
-    "typescript": "~7.0.2",
+    "typescript": "~6.0.2",
     "undici": "^7.15.0"
   },
   "engines": {


### PR DESCRIPTION
Proposal:

- Update the TypeScript dependency to version 6.x, because dependabot had updated the TypeScript dependency version to version 7.x, but this caused an error in lint since eslint v9 and neostandard are not compatible yet, making the pipeline red. ( see here: https://github.com/fastify/sse/actions/runs/29760883666/job/88414912358#step:5:14 )


Note:

- ref PR: https://github.com/fastify/busboy/pull/221